### PR TITLE
Added english automation names for some buttons

### DIFF
--- a/src/AmbientSounds.Uwp/Controls/LogoControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/LogoControl.xaml
@@ -12,6 +12,7 @@
     mc:Ignorable="d">
 
     <Button
+        x:Uid="LogoButton"
         Width="60"
         Height="60"
         extensions:VisualExtensions.CenterPoint="30,30,0"

--- a/src/AmbientSounds.Uwp/Controls/MoreButton.xaml
+++ b/src/AmbientSounds.Uwp/Controls/MoreButton.xaml
@@ -9,7 +9,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <Button Style="{StaticResource RoundButtonStyle}">
+    <Button x:Uid="MoreButton" Style="{StaticResource RoundButtonStyle}">
         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" />
         <Button.Flyout>
             <CommandBarFlyout Placement="BottomEdgeAlignedRight">

--- a/src/AmbientSounds.Uwp/Controls/PlayerControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/PlayerControl.xaml
@@ -38,6 +38,7 @@
             Background="Transparent">
             <TextBlock Margin="0,8,0,0" Text="{x:Bind converters:LocalizationConverter.ConvertSoundName(ViewModel.SoundName), Mode=OneWay}" />
             <Slider
+                x:Uid="VolumeSlider"
                 Width="120"
                 Margin="0,4,0,0"
                 Value="{x:Bind ViewModel.Volume, Mode=TwoWay}" />

--- a/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
@@ -38,6 +38,7 @@
         </ScrollViewer>
 
         <muxc:ProgressRing
+            x:Uid="SoundsLoadingRing"
             Width="40"
             Height="40"
             HorizontalAlignment="Center"

--- a/src/AmbientSounds.Uwp/Strings/cs-CZ/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/cs-CZ/Resources.resw
@@ -120,10 +120,10 @@
   <data name="CloseCompactMode.AutomationProperties.Name" xml:space="preserve">
     <value>Zavřít kompaktní režim</value>
   </data>
-	<data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
     <value>Zavřít kompaktní režim</value>
   </data>
-	<data name="Copyright.Text" xml:space="preserve">
+  <data name="Copyright.Text" xml:space="preserve">
     <value>Copyright</value>
   </data>
   <data name="CopyrightJeniusApps.Text" xml:space="preserve">
@@ -131,6 +131,9 @@
   </data>
   <data name="HelloFromVancouver.Text" xml:space="preserve">
     <value>Zdravíme z Vancouveru</value>
+  </data>
+  <data name="LogoButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="Minutes10Button.Label" xml:space="preserve">
     <value>10 minut</value>
@@ -146,6 +149,9 @@
   </data>
   <data name="Minutes60Button.Label" xml:space="preserve">
     <value>60 minut</value>
+  </data>
+  <data name="MoreButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="MoreButtonCompact.Label" xml:space="preserve">
     <value>Kompaktní režim</value>
@@ -219,10 +225,16 @@
   <data name="Sound-whitenoise" xml:space="preserve">
     <value>Bílý šum</value>
   </data>
+  <data name="SoundsLoadingRing.AutomationProperties.Name" xml:space="preserve">
+    <value />
+  </data>
   <data name="SoundUnplayable" xml:space="preserve">
     <value>Nelze přehrát zvuk</value>
   </data>
   <data name="StopTimerButton.AutomationProperties.Name" xml:space="preserve">
     <value>Zastavit časovač a vymazat čas</value>
+  </data>
+  <data name="VolumeSlider.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
@@ -132,6 +132,9 @@
   <data name="HelloFromVancouver.Text" xml:space="preserve">
     <value>Hello from Vancouver</value>
   </data>
+  <data name="LogoButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Click to view app information</value>
+  </data>
   <data name="Minutes10Button.Label" xml:space="preserve">
     <value>10 minutes</value>
   </data>
@@ -146,6 +149,9 @@
   </data>
   <data name="Minutes60Button.Label" xml:space="preserve">
     <value>60 minutes</value>
+  </data>
+  <data name="MoreButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Click to view more options</value>
   </data>
   <data name="MoreButtonCompact.Label" xml:space="preserve">
     <value>Compact mode</value>
@@ -219,10 +225,16 @@
   <data name="Sound-whitenoise" xml:space="preserve">
     <value>White noise</value>
   </data>
+  <data name="SoundsLoadingRing.AutomationProperties.Name" xml:space="preserve">
+    <value>Sounds are loading</value>
+  </data>
   <data name="SoundUnplayable" xml:space="preserve">
     <value>Cannot play sound</value>
   </data>
   <data name="StopTimerButton.AutomationProperties.Name" xml:space="preserve">
     <value>Stop the timer and clear the time</value>
+  </data>
+  <data name="VolumeSlider.AutomationProperties.Name" xml:space="preserve">
+    <value>Change sound volume</value>
   </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/es-ES/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/es-ES/Resources.resw
@@ -120,10 +120,10 @@
   <data name="CloseCompactMode.AutomationProperties.Name" xml:space="preserve">
     <value>Cerrar modo compacto</value>
   </data>
-	<data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
     <value>Cerrar modo compacto</value>
   </data>
-	<data name="Copyright.Text" xml:space="preserve">
+  <data name="Copyright.Text" xml:space="preserve">
     <value>Copyright</value>
   </data>
   <data name="CopyrightJeniusApps.Text" xml:space="preserve">
@@ -131,6 +131,9 @@
   </data>
   <data name="HelloFromVancouver.Text" xml:space="preserve">
     <value>Hola desde Vancouver</value>
+  </data>
+  <data name="LogoButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="Minutes10Button.Label" xml:space="preserve">
     <value>10 minutos</value>
@@ -146,6 +149,9 @@
   </data>
   <data name="Minutes60Button.Label" xml:space="preserve">
     <value>60 minutos</value>
+  </data>
+  <data name="MoreButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="MoreButtonCompact.Label" xml:space="preserve">
     <value>Modo compacto</value>
@@ -219,10 +225,16 @@
   <data name="Sound-whitenoise" xml:space="preserve">
     <value>Ruido blanco</value>
   </data>
+  <data name="SoundsLoadingRing.AutomationProperties.Name" xml:space="preserve">
+    <value />
+  </data>
   <data name="SoundUnplayable" xml:space="preserve">
     <value>No se pudo reproducir el sonido</value>
   </data>
   <data name="StopTimerButton.AutomationProperties.Name" xml:space="preserve">
     <value>Detener y reiniciar el temporizador</value>
+  </data>
+  <data name="VolumeSlider.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/hu-HU/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/hu-HU/Resources.resw
@@ -120,10 +120,10 @@
   <data name="CloseCompactMode.AutomationProperties.Name" xml:space="preserve">
     <value>Kompakt mód bezárása</value>
   </data>
-	<data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
     <value>Kompakt mód bezárása</value>
   </data>
-	<data name="Copyright.Text" xml:space="preserve">
+  <data name="Copyright.Text" xml:space="preserve">
     <value>Copyright</value>
   </data>
   <data name="CopyrightJeniusApps.Text" xml:space="preserve">
@@ -131,6 +131,9 @@
   </data>
   <data name="HelloFromVancouver.Text" xml:space="preserve">
     <value>Hello Vancouverből</value>
+  </data>
+  <data name="LogoButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="Minutes10Button.Label" xml:space="preserve">
     <value>10 perc</value>
@@ -146,6 +149,9 @@
   </data>
   <data name="Minutes60Button.Label" xml:space="preserve">
     <value>60 perc</value>
+  </data>
+  <data name="MoreButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="MoreButtonCompact.Label" xml:space="preserve">
     <value>Kompakt mód</value>
@@ -219,10 +225,16 @@
   <data name="Sound-whitenoise" xml:space="preserve">
     <value>Fehérzaj</value>
   </data>
+  <data name="SoundsLoadingRing.AutomationProperties.Name" xml:space="preserve">
+    <value />
+  </data>
   <data name="SoundUnplayable" xml:space="preserve">
     <value>Nem lehet lejátszani</value>
   </data>
   <data name="StopTimerButton.AutomationProperties.Name" xml:space="preserve">
     <value>Időzítő leállítása</value>
+  </data>
+  <data name="VolumeSlider.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/it-IT/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/it-IT/Resources.resw
@@ -120,10 +120,10 @@
   <data name="CloseCompactMode.AutomationProperties.Name" xml:space="preserve">
     <value>Chiudere la modalità compatta</value>
   </data>
-	<data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="CloseCompactMode.ToolTipService.ToolTip" xml:space="preserve">
     <value>Chiudere la modalità compatta</value>
   </data>
-	<data name="Copyright.Text" xml:space="preserve">
+  <data name="Copyright.Text" xml:space="preserve">
     <value>Copyright</value>
   </data>
   <data name="CopyrightJeniusApps.Text" xml:space="preserve">
@@ -131,6 +131,9 @@
   </data>
   <data name="HelloFromVancouver.Text" xml:space="preserve">
     <value>Saluti da Vancouver</value>
+  </data>
+  <data name="LogoButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="Minutes10Button.Label" xml:space="preserve">
     <value>10 minuti</value>
@@ -146,6 +149,9 @@
   </data>
   <data name="Minutes60Button.Label" xml:space="preserve">
     <value>60 minuti</value>
+  </data>
+  <data name="MoreButton.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
   <data name="MoreButtonCompact.Label" xml:space="preserve">
     <value>Modalità compatta</value>
@@ -219,10 +225,16 @@
   <data name="Sound-whitenoise" xml:space="preserve">
     <value>Rumore bianco</value>
   </data>
+  <data name="SoundsLoadingRing.AutomationProperties.Name" xml:space="preserve">
+    <value />
+  </data>
   <data name="SoundUnplayable" xml:space="preserve">
     <value>Impossibile riprodurre l'audio</value>
   </data>
   <data name="StopTimerButton.AutomationProperties.Name" xml:space="preserve">
     <value>Arrestare il timer e cancellare l'ora</value>
+  </data>
+  <data name="VolumeSlider.AutomationProperties.Name" xml:space="preserve">
+    <value />
   </data>
 </root>


### PR DESCRIPTION
Resolves #36 

✅ Added missing automation property names
✅ Tested with accessibility insights. All tests pass
✅ Tested high contrast mode and it looks good (since ambie is using all themeresource brushes)
⚠ Only English strings added so far
