### PR TITLE
Small Hungarian update

### DIFF
--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hu-HU.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hu-HU.xlf
@@ -260,7 +260,7 @@
         </trans-unit>
         <trans-unit id="ViewCatalogue.Text" translate="yes" xml:space="preserve">
           <source>More sounds</source>
-          <target state="translated">Több..</target>
+          <target state="translated">Több</target>
         </trans-unit>
         <trans-unit id="ViewCatalogueButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>View more sounds</source>


### PR DESCRIPTION
And some of the translations in the catalog needs correction:

- "Séta hó" -> "Hó"
- "Óceán hullámai" -> "Óceán"
- "Könyv oldal" -> "Könyv lapozás"
- "Repülőgép kabin" -> "Repülőgép"
- "Vákuum" -> "Porszívó"
- "Karácsonyi hang" -> "Karácsony"