### PR TITLE
Change the Icon for the Sleep Timer.

### DIFF
--- a/privacypolicy.md
+++ b/privacypolicy.md
@@ -1,7 +1,7 @@
 # Ambie - Privacy Policy 
 
 ## How We Collect and Use Information 
-
+ 
 ### Telemetry 
 Ambie collects anonymous, aggregate telemetry. You can view Ambie's open source repository on GitHub to see all the areas where the app tracks telemetry. Examples include the number of times a sound is played or downloaded from the catalogue. This information is not personally identifiable. Telemetry is used to understand what parts of Ambie is being used or not used to help guide future work. This data is not used for marketing or sales. This data is not sent to any third party. 
 

--- a/privacypolicy.md
+++ b/privacypolicy.md
@@ -1,7 +1,7 @@
 # Ambie - Privacy Policy 
 
 ## How We Collect and Use Information 
- 
+
 ### Telemetry 
 Ambie collects anonymous, aggregate telemetry. You can view Ambie's open source repository on GitHub to see all the areas where the app tracks telemetry. Examples include the number of times a sound is played or downloaded from the catalogue. This information is not personally identifiable. Telemetry is used to understand what parts of Ambie is being used or not used to help guide future work. This data is not used for marketing or sales. This data is not sent to any third party. 
 

--- a/src/AmbientSounds.Uwp/Controls/SleepTimerControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/SleepTimerControl.xaml
@@ -19,7 +19,7 @@
 
     <StackPanel Orientation="Horizontal">
         <Button x:Uid="SleepTimerButton" Style="{StaticResource TransparentRoundButtonStyle}">
-            <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEC1E;" />
+            <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEBFE;" />
             <Button.Flyout>
                 <muxc:CommandBarFlyout Placement="BottomEdgeAlignedLeft">
                     <muxc:CommandBarFlyout.PrimaryCommands>


### PR DESCRIPTION
The moon icon doesn't fit with the functionality it does. It would be better if it was something like a timer icon.

