### PR TITLE
Added items reorder animation to sounds grid

### DIFF
--- a/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
@@ -13,6 +13,7 @@
         <ScrollViewer>
             <muxc:ItemsRepeater
                 x:Uid="SoundsGridView"
+                x:Name="SoundsGridView"
                 Margin="{x:Bind InnerMargin, Mode=OneWay}"
                 ElementPrepared="{x:Bind OnElementPrepared}"
                 ItemTemplate="{x:Bind ItemTemplate, Mode=OneWay}"

--- a/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml.cs
+++ b/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml.cs
@@ -1,7 +1,11 @@
-﻿using AmbientSounds.ViewModels;
+﻿using System;
+using AmbientSounds.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Toolkit.Uwp.UI;
+using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
 using MUXC = Microsoft.UI.Xaml.Controls;
 
 #nullable enable
@@ -10,6 +14,11 @@ namespace AmbientSounds.Controls
 {
     public sealed partial class SoundGridControl : UserControl
     {
+        /// <summary>
+        /// The duration for the items reorder animations, in milliseconds.
+        /// </summary>
+        private const int ReorderAnimationDuration = 250;
+
         public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(
             nameof(ItemTemplate),
             typeof(DataTemplate),
@@ -28,12 +37,19 @@ namespace AmbientSounds.Controls
             typeof(SoundGridControl),
             new PropertyMetadata(new Thickness(0, 0, 0, 0)));
 
+        /// <summary>
+        /// The <see cref="ImplicitAnimationCollection"/> instance to animate items being reordered.
+        /// </summary>
+        private readonly ImplicitAnimationCollection _reorderAnimationCollection;
+
         public SoundGridControl()
         {
             this.InitializeComponent();
             this.DataContext = App.Services.GetRequiredService<SoundListViewModel>();
             this.Loaded += async (_, _) => { await ViewModel.LoadCommand.ExecuteAsync(null); };
             this.Unloaded += (_, _) => { ViewModel.Dispose(); };
+
+            _reorderAnimationCollection = CreateReorderAnimationCollection(SoundsGridView);
         }
 
         public SoundListViewModel ViewModel => (SoundListViewModel)this.DataContext;
@@ -66,6 +82,11 @@ namespace AmbientSounds.Controls
         {
             if (sender.DataContext is SoundListViewModel listVm)
             {
+                if (args.Element is UIElement element)
+                {
+                    element.GetVisual().ImplicitAnimations = _reorderAnimationCollection;
+                }
+
                 if (args.Element is SoundItemControl c)
                 {
                     c.ViewModel = listVm.Sounds[args.Index];
@@ -75,6 +96,31 @@ namespace AmbientSounds.Controls
                     l.ViewModel = listVm.Sounds[args.Index];
                 }
             }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ImplicitAnimationCollection"/> instance to animate the visual of items within a <see cref="MUXC.ItemsRepeater"/> control.
+        /// </summary>
+        /// <param name="itemsRepeater">The input <see cref="MUXC.ItemsRepeater"/> to create the animation for.</param>
+        /// <returns>A new <see cref="ImplicitAnimationCollection"/> instance to animate items within <paramref name="itemsRepeater"/>.</returns>
+        private static ImplicitAnimationCollection CreateReorderAnimationCollection(MUXC.ItemsRepeater itemsRepeater)
+        {
+            Compositor compositor = ElementCompositionPreview.GetElementVisual(itemsRepeater).Compositor;
+            Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
+
+            offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
+            offsetAnimation.Duration = TimeSpan.FromMilliseconds(ReorderAnimationDuration);
+            offsetAnimation.Target = nameof(Visual.Offset);
+
+            CompositionAnimationGroup animationGroup = compositor.CreateAnimationGroup();
+
+            animationGroup.Add(offsetAnimation);
+
+            ImplicitAnimationCollection animationCollection = compositor.CreateImplicitAnimationCollection();
+
+            animationCollection[nameof(Visual.Offset)] = animationGroup;
+
+            return animationCollection;
         }
     }
 }


### PR DESCRIPTION
This PR reintroduces the items reorder animation for sounds in the `ItemsRepeater` control:

![lslKmItDGh](https://user-images.githubusercontent.com/10199417/123550237-f2825680-d76c-11eb-9baa-a37327742246.gif)

The implementation is very similar to that of [`ItemsReorderAnimation`](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/main/Microsoft.Toolkit.Uwp.UI.Animations/ItemsReorderAnimation.cs) from the Windows Community Toolkit, with the main differences being that in this case the animation collection is just cached in a local field given that only one instance is needed per control (and we're not exposing this as a helper for other consumers), and that we're using `ItemsRepeater.OnElementPrepared` to inject the animation directly into each realized control instead of leveraging the container changed events to attach the animations to item containers (which are no longer present in `ItemsRepeater`).