### PR TITLE
Added workaround for offset animation

### DIFF
--- a/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/SoundGridControl.xaml
@@ -16,6 +16,7 @@
                 x:Uid="SoundsGridView"
                 Margin="{x:Bind InnerMargin, Mode=OneWay}"
                 ElementPrepared="OnElementPrepared"
+                ElementClearing="SoundsGridView_ElementClearing"
                 ItemTemplate="{x:Bind ItemTemplate, Mode=OneWay}"
                 ItemsSource="{x:Bind ViewModel.Sounds}"
                 Layout="{x:Bind Layout, Mode=OneWay}"


### PR DESCRIPTION
Added a comment explaining how this works. Played around with various workarounds for a bit but couldn't really get anything better than this in all scenarios without having to possibly resort to much more expensive solutions (eg. timers, delays, manipulation events and whatnot). This runs all on the compositor thread, so at least the UI remains completely smooth. It fixes the issue with those unwanted offsets animations, at the cost of a slight delay when snapping from Desktop to Mobile mode in the UI.