### PR TITLE
Change the ITimerService from Singleton to Transient

### DIFF
--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -1,12 +1,20 @@
-﻿using AmbientSounds.Services;
+﻿using AmbientSounds.Constants;
+using AmbientSounds.Factories;
+using AmbientSounds.Services;
 using AmbientSounds.Services.Uwp;
 using AmbientSounds.ViewModels;
-using AmbientSounds.Constants;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Toolkit.Diagnostics;
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.ApplicationModel.AppService;
+using Windows.ApplicationModel.Background;
 using Windows.ApplicationModel.Core;
+using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.System.Profile;
 using Windows.UI;
@@ -14,14 +22,6 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using System.Threading.Tasks;
-using System.Net.Http;
-using AmbientSounds.Factories;
-using Windows.ApplicationModel.AppService;
-using Windows.ApplicationModel.Background;
-using Windows.Foundation.Collections;
-using Windows.ApplicationModel;
-using Microsoft.Identity.Client.Extensibility;
 
 #nullable enable
 
@@ -310,9 +310,9 @@ namespace AmbientSounds
                 .AddSingleton<IDialogService, DialogService>()
                 .AddSingleton<IFileDownloader, FileDownloader>()
                 .AddSingleton<ISoundVmFactory, SoundVmFactory>()
-                .AddSingleton<IUserSettings, LocalSettings>() 
+                .AddSingleton<IUserSettings, LocalSettings>()
                 .AddSingleton<IShareLinkBuilder, ShareLinkBuilder>()
-                .AddSingleton<ITimerService, TimerService>()
+                .AddTransient<ITimerService, TimerService>()
                 .AddSingleton<ISoundMixService, SoundMixService>()
                 .AddSingleton<IRenamer, Renamer>()
                 .AddSingleton<ILinkProcessor, LinkProcessor>()


### PR DESCRIPTION
Change the ITimerService from Singleton to Transient, to prevent TimerIntervalElapsed event from being triggered in the background.

How to reproduce the issue.
1. Run the debugger
2. Go to settings
3. Enable the screensaver
4. Play some music
5. Minimize Ambie Window and wait for the screensaver timer to be trigger.

ScreensaverViewModel -> TimerIntervalElapsed will be triggered CycleImages() as expected.
SleepTimerViewModel -> TimerElapsed will be also triggered pausing the player. 

NOTE: The SleepTimerControl have an "Unloaded" event that prevents this from happening, but it only works if the app is visible
if the app is minimized that event will never be triggered.