### PR TITLE
Animated background fixes

### DIFF
--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
@@ -568,4 +568,13 @@
   <data name="ComputeShader.Octagrams" xml:space="preserve">
     <value>Octagrams</value>
   </data>
+  <data name="RenderingErrorInfo.Message" xml:space="preserve">
+    <value>There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by opening an issue on GitHub.</value>
+  </data>
+  <data name="RenderingErrorLink.Content" xml:space="preserve">
+    <value>Report the issue</value>
+  </data>
+  <data name="RenderingErrorInfo.Title" xml:space="preserve">
+    <value>Rendering error</value>
+  </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
@@ -569,7 +569,7 @@
     <value>Octagrams</value>
   </data>
   <data name="RenderingErrorInfo.Message" xml:space="preserve">
-    <value>There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by sending us an email.</value>
+    <value>There was an issue displaying the screensaver. Try restarting Ambie, or contact us if the issue persists.</value>
   </data>
   <data name="RenderingErrorLink.Content" xml:space="preserve">
     <value>Report the issue</value>

--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
@@ -569,7 +569,7 @@
     <value>Octagrams</value>
   </data>
   <data name="RenderingErrorInfo.Message" xml:space="preserve">
-    <value>There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by opening an issue on GitHub.</value>
+    <value>There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by sending us an email.</value>
   </data>
   <data name="RenderingErrorLink.Content" xml:space="preserve">
     <value>Report the issue</value>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
@@ -66,17 +66,12 @@
         <muxc:InfoBar
             x:Name="RenderingErrorInfoBar"
             x:Uid="RenderingErrorInfo"
-            Title="Rendering error"
             VerticalAlignment="Bottom"
             x:Load="False"
             IsOpen="True"
-            Message="There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by sending us an email."
             Severity="Error">
             <muxc:InfoBar.ActionButton>
-                <HyperlinkButton
-                    x:Uid="RenderingErrorLink"
-                    Content="Report the issue"
-                    NavigateUri="mailto:jenius_apps@outlook.com" />
+                <HyperlinkButton x:Uid="RenderingErrorLink" NavigateUri="mailto:jenius_apps@outlook.com" />
             </muxc:InfoBar.ActionButton>
         </muxc:InfoBar>
     </Grid>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
@@ -70,13 +70,13 @@
             VerticalAlignment="Bottom"
             x:Load="False"
             IsOpen="True"
-            Message="There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by opening an issue on GitHub."
+            Message="There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by sending us an email."
             Severity="Error">
             <muxc:InfoBar.ActionButton>
                 <HyperlinkButton
                     x:Uid="RenderingErrorLink"
                     Content="Report the issue"
-                    NavigateUri="https://github.com/jenius-apps/ambie/issues" />
+                    NavigateUri="mailto:jenius_apps@outlook.com" />
             </muxc:InfoBar.ActionButton>
         </muxc:InfoBar>
     </Grid>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
@@ -7,6 +7,7 @@
     xmlns:converters="using:AmbientSounds.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Name="RootPage"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
@@ -55,9 +56,28 @@
             Visibility="{x:Bind ViewModel.VideoPlayerVisible, Mode=OneWay}" />
 
         <computeSharp:AnimatedComputeShaderPanel
+            RenderingFailed="AnimatedComputeShaderPanel_RenderingFailed"
             ShaderRunner="{x:Bind converters:PixelShaderToShaderRunnerConverter.Convert(ViewModel.AnimatedBackgroundName), Mode=OneWay}"
             Visibility="{x:Bind ViewModel.AnimatedBackgroundVisible, Mode=OneWay}" />
 
         <controls:Screensaver x:Name="ScreensaverControl" x:Load="{x:Bind ViewModel.SlideshowVisible, Mode=OneWay}" />
+
+        <!--  Rendering error bar  -->
+        <muxc:InfoBar
+            x:Name="RenderingErrorInfoBar"
+            x:Uid="RenderingErrorInfo"
+            Title="Rendering error"
+            VerticalAlignment="Bottom"
+            x:Load="False"
+            IsOpen="True"
+            Message="There was an error that caused the rendering to fail, try restarting the app. If the issue persists, please report it by opening an issue on GitHub."
+            Severity="Error">
+            <muxc:InfoBar.ActionButton>
+                <HyperlinkButton
+                    x:Uid="RenderingErrorLink"
+                    Content="Report the issue"
+                    NavigateUri="https://github.com/jenius-apps/ambie/issues" />
+            </muxc:InfoBar.ActionButton>
+        </muxc:InfoBar>
     </Grid>
 </Page>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using AmbientSounds.Constants;
 using AmbientSounds.Services;
 using AmbientSounds.ViewModels;
+using ComputeSharp.Uwp;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -159,6 +161,20 @@ namespace AmbientSounds.Views
         private void GoBack(object sender, RoutedEventArgs e)
         {
             GoBack();
+        }
+
+        private void AnimatedComputeShaderPanel_RenderingFailed(AnimatedComputeShaderPanel sender, Exception args)
+        {
+            var telemetry = App.Services.GetRequiredService<ITelemetry>();
+
+            telemetry.TrackError(args, new Dictionary<string, string>()
+            {
+                { "name", ViewModel.AnimatedBackgroundName ?? string.Empty },
+            });
+
+            InfoBar infoBar = (InfoBar)FindName(nameof(RenderingErrorInfoBar));
+
+            infoBar.IsOpen = true;
         }
     }
 }

--- a/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
@@ -208,6 +208,7 @@ namespace AmbientSounds.ViewModels
 
             if (menuItemId == DefaultId)
             {
+                AnimatedBackgroundName = null;
                 VideoSource = new Uri(DefaultVideoSource);
                 SlideshowVisible = true;
             }
@@ -238,6 +239,7 @@ namespace AmbientSounds.ViewModels
                 var path = await _videoService.GetFilePathAsync(menuItemId);
                 if (!string.IsNullOrEmpty(path))
                 {
+                    AnimatedBackgroundName = null;
                     SlideshowVisible = false;
 
                     try


### PR DESCRIPTION
This PR includes the following tweaks:

- Fix the screensaver always reverting back to shaders
- Added telemetry when a rendering failure happens
- Also display an `InfoBar` with some info if a rendering failure happens

<img width="956" alt="image" src="https://user-images.githubusercontent.com/10199417/157032865-95969917-303e-42c9-9e48-49fe02cc59d7.png">
