### PR TITLE
Support protocol launch

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Services\MixMediaPlayerService.cs" />
     <Compile Include="Services\MsalClient.cs" />
     <Compile Include="Services\PreviewService.cs" />
+    <Compile Include="Services\ProtocolLaunchController.cs" />
     <Compile Include="Services\StoreService.cs" />
     <Compile Include="Services\SystemInfoProvider.cs" />
     <Compile Include="Services\DialogService.cs" />
@@ -502,6 +503,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="QueryString.NET">
+      <Version>1.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -108,7 +108,7 @@ namespace AmbientSounds
         protected override async void OnLaunched(LaunchActivatedEventArgs e)
         {
             await ActivateAsync(e.PrelaunchActivated);
-            if(e.Kind == ActivationKind.Protocol)
+            if (e.Kind == ActivationKind.Protocol)
             {
                 HandleProtocolLaunch((ProtocolActivatedEventArgs)(IActivatedEventArgs)e);
             }
@@ -122,7 +122,7 @@ namespace AmbientSounds
                 new PartnerCentreNotificationRegistrar().TrackLaunch(toastActivationArgs.Argument);
                 await ActivateAsync(false);
             }
-            else if(args is ProtocolActivatedEventArgs protocolActivatedEventArgs)
+            else if (args is ProtocolActivatedEventArgs protocolActivatedEventArgs)
             {
                 await ActivateAsync(false);
                 HandleProtocolLaunch(protocolActivatedEventArgs);
@@ -222,7 +222,7 @@ namespace AmbientSounds
             {
                 var uri = protocolArgs.Uri;
 
-                if(uri.Host == "launch")
+                if (uri.Host == "launch")
                 {
                     var arg = protocolArgs.Uri.Query.Replace("?", string.Empty);
                     Services.GetService<ProtocolLaunchController>()?.ProcessLaunchProtocolArguments(arg);

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -218,8 +218,20 @@ namespace AmbientSounds
 
         private void HandleProtocolLaunch(ProtocolActivatedEventArgs protocolArgs)
         {
-            var arg = protocolArgs.Uri.Query.Replace("?", string.Empty);
-            Services.GetService<ProtocolLaunchController>()?.ProcessProtocolArguments(arg);
+            try
+            {
+                var uri = protocolArgs.Uri;
+
+                if(uri.Host == "launch")
+                {
+                    var arg = protocolArgs.Uri.Query.Replace("?", string.Empty);
+                    Services.GetService<ProtocolLaunchController>()?.ProcessLaunchProtocolArguments(arg);
+                }
+            }
+            catch (UriFormatException)
+            {
+                // An invalid Uri may have been passed in.
+            }
         }
 
         private void SetMinSize()

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -108,9 +108,10 @@ namespace AmbientSounds
         protected override async void OnLaunched(LaunchActivatedEventArgs e)
         {
             await ActivateAsync(e.PrelaunchActivated);
-            if (e.Kind == ActivationKind.Protocol)
+            if (e is IActivatedEventArgs activatedEventArgs
+                && activatedEventArgs is IProtocolActivatedEventArgs protocolArgs)
             {
-                HandleProtocolLaunch((ProtocolActivatedEventArgs)(IActivatedEventArgs)e);
+                HandleProtocolLaunch(protocolArgs);
             }
         }
 
@@ -216,7 +217,7 @@ namespace AmbientSounds
             await BackgroundDownloadService.Instance.DiscoverActiveDownloadsAsync();
         }
 
-        private void HandleProtocolLaunch(ProtocolActivatedEventArgs protocolArgs)
+        private void HandleProtocolLaunch(IProtocolActivatedEventArgs protocolArgs)
         {
             try
             {

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -123,7 +123,7 @@ namespace AmbientSounds
                 new PartnerCentreNotificationRegistrar().TrackLaunch(toastActivationArgs.Argument);
                 await ActivateAsync(false);
             }
-            else if (args is ProtocolActivatedEventArgs protocolActivatedEventArgs)
+            else if (args is IProtocolActivatedEventArgs protocolActivatedEventArgs)
             {
                 await ActivateAsync(false);
                 HandleProtocolLaunch(protocolActivatedEventArgs);

--- a/src/AmbientSounds.Uwp/Package.appxmanifest
+++ b/src/AmbientSounds.Uwp/Package.appxmanifest
@@ -49,14 +49,14 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" xmlns:a="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"  BackgroundColor="black"/>
       </uap:VisualElements>
       <Extensions>
-		<uap:Extension Category="windows.appService">
-			<uap:AppService Name="com.jeniusapps.ambie" />
-		</uap:Extension>
-		<uap:Extension Category="windows.protocol" EntryPoint="AmbientSounds.App">
-		  <uap:Protocol Name="ambie">
-		  <uap:DisplayName>AmbientSounds</uap:DisplayName>
-		</uap:Protocol>
-		</uap:Extension>
+		    <uap:Extension Category="windows.appService">
+			    <uap:AppService Name="com.jeniusapps.ambie" />
+		    </uap:Extension>
+		    <uap:Extension Category="windows.protocol" EntryPoint="AmbientSounds.App">
+		      <uap:Protocol Name="ambie">
+		        <uap:DisplayName>AmbientSounds</uap:DisplayName>
+		      </uap:Protocol>
+		    </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/src/AmbientSounds.Uwp/Package.appxmanifest
+++ b/src/AmbientSounds.Uwp/Package.appxmanifest
@@ -52,6 +52,11 @@
 		<uap:Extension Category="windows.appService">
 			<uap:AppService Name="com.jeniusapps.ambie" />
 		</uap:Extension>
+		<uap:Extension Category="windows.protocol" EntryPoint="AmbientSounds.App">
+		  <uap:Protocol Name="ambie">
+		  <uap:DisplayName>AmbientSounds</uap:DisplayName>
+		</uap:Protocol>
+		</uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
+++ b/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
@@ -24,7 +24,7 @@ namespace AmbientSounds.Services
             _navigator = navigator;
         }
 
-        public void ProcessProtocolArguments(string arguments)
+        public void ProcessLaunchProtocolArguments(string arguments)
         {
             var query = QueryString.Parse(arguments);
             query.TryGetValue(CompactKey, out var isCompact);

--- a/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
+++ b/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.QueryStringDotNET;
 using Microsoft.Toolkit.Diagnostics;
 using System;
-using Windows.System;
 
 #nullable enable
 
@@ -11,10 +10,9 @@ namespace AmbientSounds.Services
     {
         private readonly IMixMediaPlayerService _player;
         private readonly INavigator _navigator;
-        private readonly DispatcherQueue _dispatcherQueue;
 
         private const string CompactKey = "compact";
-        private const string AutoPlayKey = "autoplay";
+        private const string AutoPlayKey = "autoPlay";
 
         public ProtocolLaunchController(
             IMixMediaPlayerService player,
@@ -24,7 +22,6 @@ namespace AmbientSounds.Services
 
             _player = player;
             _navigator = navigator;
-            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         }
 
         public void ProcessProtocolArguments(string arguments)

--- a/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
+++ b/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
@@ -37,7 +37,7 @@ namespace AmbientSounds.Services
                 _navigator.ToCompact();
             }
 
-            if(!string.IsNullOrEmpty(isAutoPlay) && Convert.ToBoolean(isAutoPlay))
+            if (!string.IsNullOrEmpty(isAutoPlay) && Convert.ToBoolean(isAutoPlay))
             {
                 // Auto play music.
                 _player.Play();

--- a/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
+++ b/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
@@ -19,6 +19,7 @@ namespace AmbientSounds.Services
             INavigator navigator)
         {
             Guard.IsNotNull(player, nameof(player));
+            Guard.IsNotNull(navigator, nameof(navigator));
 
             _player = player;
             _navigator = navigator;

--- a/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
+++ b/src/AmbientSounds.Uwp/Services/ProtocolLaunchController.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.QueryStringDotNET;
+using Microsoft.Toolkit.Diagnostics;
+using System;
+using Windows.System;
+
+#nullable enable
+
+namespace AmbientSounds.Services
+{
+    public class ProtocolLaunchController
+    {
+        private readonly IMixMediaPlayerService _player;
+        private readonly INavigator _navigator;
+        private readonly DispatcherQueue _dispatcherQueue;
+
+        private const string CompactKey = "compact";
+        private const string AutoPlayKey = "autoplay";
+
+        public ProtocolLaunchController(
+            IMixMediaPlayerService player,
+            INavigator navigator)
+        {
+            Guard.IsNotNull(player, nameof(player));
+
+            _player = player;
+            _navigator = navigator;
+            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+        }
+
+        public void ProcessProtocolArguments(string arguments)
+        {
+            var query = QueryString.Parse(arguments);
+            query.TryGetValue(CompactKey, out var isCompact);
+            query.TryGetValue(AutoPlayKey, out var isAutoPlay);
+
+            if (!string.IsNullOrEmpty(isCompact) && Convert.ToBoolean(isCompact))
+            {
+                // Enter compact view.
+                _navigator.ToCompact();
+            }
+
+            if(!string.IsNullOrEmpty(isAutoPlay) && Convert.ToBoolean(isAutoPlay))
+            {
+                // Auto play music.
+                _player.Play();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Although Ambie supports `AppService`, if you want to play music through it, the app must be in the foreground. So for other third-party applications, if you want to evoke Ambie to play music, then protocol launch is a better way.

Here is the initial definition (can be extended later if needed)

**Protocol name**: ambie
**Host name**: launch
|Argument name|type|description|
|-|-|-|
|compact|boolean|Enter Compact mode after app launch|
|autoPlay|boolean|Autoplay after app launch|

Example: `ambie://launch?compact=true&autoPlay=true`

## PR type

What is the purpose of this PR?

- Feature

## What is the current behavior?

Ambie needs to be started in the foreground before play commands can be used externally through the App Service

## What is the new behavior?

External applications can directly evoke Ambie through protocol launch, and choose whether to enter small window mode and autoplay.

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] Use link: `ambie://launch?compact=true&autoPlay=true` to launch the app
- [x] Use link: `ambie://launch` to launch the app

## Remark

I'm integrating Ambie for my app [Clean Reader](https://github.com/Clean-Reader/CleanReader.Desktop) to allow users to turn on white noise when they start reading, helping people focus on reading.
But currently, I have to launch Ambie first through `PackageManager`, and then call `AppService`. During this period, because the startup time of Ambie cannot be accurately determined, the call of AppService may fail. So I need a way to get Ambie to start as expected, I just need to provide some parameters and Ambie starts as my expected behavior.
