### PR TITLE
Make close button animation smooth in active track item

### DIFF
--- a/src/AmbientSounds.Uwp/Controls/ActiveTrackList.xaml
+++ b/src/AmbientSounds.Uwp/Controls/ActiveTrackList.xaml
@@ -125,7 +125,7 @@
                                                     <!--  Lightweight styling to mimic red close button  -->
                                                     <ResourceDictionary.ThemeDictionaries>
                                                         <ResourceDictionary x:Key="Dark">
-                                                            <SolidColorBrush x:Key="ButtonBackground" Color="Transparent" />
+                                                            <SolidColorBrush x:Key="ButtonBackground" Color="#00c42b1c" />
                                                             <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#c42b1c" />
                                                             <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#b5291e" />
                                                             <SolidColorBrush x:Key="ButtonBorderBrush" Color="Transparent" />
@@ -134,7 +134,7 @@
                                                             <SolidColorBrush x:Key="ButtonForegroundPressed" Color="LightGray" />
                                                         </ResourceDictionary>
                                                         <ResourceDictionary x:Key="Light">
-                                                            <SolidColorBrush x:Key="ButtonBackground" Color="Transparent" />
+                                                            <SolidColorBrush x:Key="ButtonBackground" Color="#00c42b1c" />
                                                             <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#c42b1c" />
                                                             <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#b5291e" />
                                                             <SolidColorBrush x:Key="ButtonBorderBrush" Color="Transparent" />


### PR DESCRIPTION
Colors.Transparent is equal to #00FFFFFF. This means that if you transition between Transparent and another color, you will get white fading out instead of the desired color

Comparison:

https://user-images.githubusercontent.com/18747724/172040059-cf80146b-58ea-4eb8-ab01-f6a3b1b2d4b4.mp4
