### PR TITLE
Enable ComputeSharp screensaver on Xbox Series S and X

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -19,6 +19,7 @@
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <LangVersion>10.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseDotNetNativeSharedAssemblyFrameworkPackage>false</UseDotNetNativeSharedAssemblyFrameworkPackage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -233,6 +234,10 @@
     <Compile Include="Converters\LocalizationConverter.cs" />
     <Compile Include="Converters\ThemeConverter.cs" />
     <Compile Include="Converters\VisibilityConverter.cs" />
+    <Compile Include="GamingInformation\GamingDeviceInformation.cs" />
+    <Compile Include="GamingInformation\GAMING_DEVICE_MODEL_INFORMATION.cs" />
+    <Compile Include="GamingInformation\GAMING_DEVICE_DEVICE_ID.cs" />
+    <Compile Include="GamingInformation\GAMING_DEVICE_VENDOR_ID.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\AppServiceController.cs" />
     <Compile Include="Services\AppSettings.cs" />

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -89,7 +89,9 @@ namespace AmbientSounds
 
         public static bool IsDesktop => AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Desktop";
 
-        public static bool IsTenFoot => AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Xbox" || _isTenFootPc;
+        public static bool IsXbox => AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Xbox";
+
+        public static bool IsTenFoot => IsXbox || _isTenFootPc;
 
         public static bool IsRightToLeftLanguage
         {

--- a/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_DEVICE_ID.cs
+++ b/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_DEVICE_ID.cs
@@ -1,0 +1,33 @@
+﻿namespace AmbientSounds.GamingInformation;
+
+/// <summary>
+/// Indicates the type of device that the game is running on.
+/// </summary>
+/// <remarks>See <see href="https://docs.microsoft.com/windows/win32/api/gamingdeviceinformation/ne-gamingdeviceinformation-gaming_device_device_id"/>.</remarks>
+public enum GAMING_DEVICE_DEVICE_ID
+{
+    /// <summary>
+    /// The device is not in the Xbox family.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_NONE = 0,
+
+    /// <summary>
+    /// The device is an Xbox One (original).
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_ONE = 0x768BAE26,
+
+    /// <summary>
+    /// The device is an Xbox One S.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_ONE_S = 0x2A7361D9,
+
+    /// <summary>
+    /// The device is an Xbox One X.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_ONE_X = 0x5AD617C7,
+
+    /// <summary>
+    /// The device is an Xbox One X dev kit.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_ONE_X_DEVKIT = 0x10F7CDE3
+}

--- a/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_DEVICE_ID.cs
+++ b/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_DEVICE_ID.cs
@@ -29,5 +29,20 @@ public enum GAMING_DEVICE_DEVICE_ID
     /// <summary>
     /// The device is an Xbox One X dev kit.
     /// </summary>
-    GAMING_DEVICE_DEVICE_ID_XBOX_ONE_X_DEVKIT = 0x10F7CDE3
+    GAMING_DEVICE_DEVICE_ID_XBOX_ONE_X_DEVKIT = 0x10F7CDE3,
+
+    /// <summary>
+    /// The device is an Xbox Series S.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_S = 0x1D27FABB,
+
+    /// <summary>
+    /// The device is an Xbox Series X.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_X = 0x2F7A3DFF,
+
+    /// <summary>
+    /// The device is an Xbox Series X dev kit.
+    /// </summary>
+    GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_X_DEVKIT = unchecked((int)0xDE8A5661)
 }

--- a/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_MODEL_INFORMATION.cs
+++ b/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_MODEL_INFORMATION.cs
@@ -1,0 +1,18 @@
+﻿namespace AmbientSounds.GamingInformation;
+
+/// <summary>
+/// Contains information about the device that the game is running on.
+/// </summary>
+/// <remarks>See <see href="https://docs.microsoft.com/windows/win32/api/gamingdeviceinformation/ns-gamingdeviceinformation-gaming_device_model_information"/>.</remarks>
+public struct GAMING_DEVICE_MODEL_INFORMATION
+{
+    /// <summary>
+    /// The vendor of the device.
+    /// </summary>
+    public GAMING_DEVICE_VENDOR_ID vendorId;
+
+    /// <summary>
+    /// The type of device.
+    /// </summary>
+    public GAMING_DEVICE_DEVICE_ID deviceId;
+}

--- a/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_VENDOR_ID.cs
+++ b/src/AmbientSounds.Uwp/GamingInformation/GAMING_DEVICE_VENDOR_ID.cs
@@ -1,0 +1,18 @@
+﻿namespace AmbientSounds.GamingInformation;
+
+/// <summary>
+/// Indicates the vendor of the console that the game is running on.
+/// </summary>
+/// <remarks>See <see href="https://docs.microsoft.com/windows/win32/api/gamingdeviceinformation/ne-gamingdeviceinformation-gaming_device_vendor_id"/>.</remarks>
+public enum GAMING_DEVICE_VENDOR_ID
+{
+    /// <summary>
+    /// The vendor of the device is not known.
+    /// </summary>
+    GAMING_DEVICE_VENDOR_ID_NONE = 0,
+
+    /// <summary>
+    /// The vendor of the device is Microsoft.
+    /// </summary>
+    GAMING_DEVICE_VENDOR_ID_MICROSOFT = unchecked((int)0xC2EC5032)
+}

--- a/src/AmbientSounds.Uwp/GamingInformation/GamingDeviceInformation.cs
+++ b/src/AmbientSounds.Uwp/GamingInformation/GamingDeviceInformation.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace AmbientSounds.GamingInformation;
+
+/// <summary>
+/// APIs form the <c>GamingDeviceInformation.h</c> header.
+/// </summary>
+/// <remarks>See <see href="https://docs.microsoft.com/windows/win32/api/_gamingdvcinfo/"/>.</remarks>
+public static class GamingDeviceInformation
+{
+    /// <summary>
+    /// Gets information about the device that the game is running on.
+    /// </summary>
+    /// <param name="information">A structure containing information about the device that the game is running on.</param>
+    /// <returns>An <c>HRESULT</c> for the operation.</returns>
+    /// <remarks>See <see href="https://docs.microsoft.com/windows/win32/api/gamingdeviceinformation/nf-gamingdeviceinformation-getgamingdevicemodelinformation"/>.</remarks>
+    [DllImport("api-ms-win-gaming-deviceinformation-l1-1-0", ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    public static extern unsafe int GetGamingDeviceModelInformation(GAMING_DEVICE_MODEL_INFORMATION* information);
+}

--- a/src/AmbientSounds.Uwp/Services/SystemInfoProvider.cs
+++ b/src/AmbientSounds.Uwp/Services/SystemInfoProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Toolkit.Uwp.Helpers;
+﻿using AmbientSounds.GamingInformation;
+using Microsoft.Toolkit.Uwp.Helpers;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,6 +36,26 @@ namespace AmbientSounds.Services.Uwp
         public bool IsTenFoot()
         {
             return App.IsTenFoot;
+        }
+
+        /// <inheritdoc/>
+        public unsafe bool IsXboxSeries()
+        {
+            if (App.IsXbox)
+            {
+                GAMING_DEVICE_MODEL_INFORMATION information = default;
+
+                if (GamingDeviceInformation.GetGamingDeviceModelInformation(&information) == 0)
+                {
+                    return
+                        information.deviceId is
+                        GAMING_DEVICE_DEVICE_ID.GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_S or
+                        GAMING_DEVICE_DEVICE_ID.GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_X or
+                        GAMING_DEVICE_DEVICE_ID.GAMING_DEVICE_DEVICE_ID_XBOX_SERIES_X_DEVKIT;
+                }
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>

--- a/src/AmbientSounds/Services/ISystemInfoProvider.cs
+++ b/src/AmbientSounds/Services/ISystemInfoProvider.cs
@@ -28,6 +28,12 @@ namespace AmbientSounds.Services
         bool IsTenFoot();
 
         /// <summary>
+        /// Checks whether the current device is an Xbox Series S or X device.
+        /// </summary>
+        /// <returns>Whether the current device is an Xbox Series S or X device.</returns>
+        bool IsXboxSeries();
+
+        /// <summary>
         /// Retrieves list of paths for background images
         /// available in the device.
         /// </summary>

--- a/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
@@ -153,8 +153,9 @@ namespace AmbientSounds.ViewModels
             MenuItems.Add(new FlyoutMenuItem(DefaultId, _localizer.GetString(DefaultId), screensaverCommand, DefaultId, true));
             MenuItems.Add(new FlyoutMenuItem(DarkScreenId, _localizer.GetString("SettingsThemeDarkRadio/Content"), screensaverCommand, DarkScreenId, true));
 
-            // Only enable compute shaders on desktop and when not using the WARP device
-            if (_systemInfoProvider.IsDesktop() &&
+            // Only enable compute shaders on desktop or on Xbox Series S or X devices, and when not using the WARP device.
+            // ComputeSharp needs DX12 APIs with FL11 and SM6.0 support, which is not available for UWP apps on Xbox One.
+            if ((_systemInfoProvider.IsDesktop() || _systemInfoProvider.IsXboxSeries()) &&
                 GraphicsDevice.Default.IsHardwareAccelerated)
             {
                 // Animated backgrounds


### PR DESCRIPTION
This PR enables the ComputeSharp-powered animated screensavers on Xbox Series S and X. This is possible because UWP apps running on the new consoles can use DX12 APIs with the necessary feature set that allows ComputeSharp to work. The PR also includes a new system information API that's used to detect when the device is an Xbox One, so the feature can remain disabled there.