### PR TITLE
Screensaver fullscreen button

### DIFF
--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -50,6 +50,10 @@ namespace AmbientSounds.Views
             var navigator = SystemNavigationManager.GetForCurrentView();
             navigator.BackRequested += OnBackRequested;
 
+            var view = ApplicationView.GetForCurrentView();
+            IsFullscreen = view.IsFullScreenMode;
+            this.Bindings.Update();
+
             if (App.IsTenFoot)
             {
                 GoBackButton.Focus(Windows.UI.Xaml.FocusState.Programmatic);

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -52,7 +52,6 @@ namespace AmbientSounds.Views
 
             var view = ApplicationView.GetForCurrentView();
             IsFullscreen = view.IsFullScreenMode;
-            this.Bindings.Update();
 
             if (App.IsTenFoot)
             {

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -45,7 +45,8 @@ namespace AmbientSounds.Views
             });
 
             var coreWindow = CoreWindow.GetForCurrentThread();
-            coreWindow.KeyDown += CataloguePage_KeyDown;
+            coreWindow.KeyDown += CoreWindow_KeyDown;
+            coreWindow.SizeChanged += CoreWindow_SizeChanged;
             var navigator = SystemNavigationManager.GetForCurrentView();
             navigator.BackRequested += OnBackRequested;
 
@@ -61,7 +62,8 @@ namespace AmbientSounds.Views
             ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
 
             var coreWindow = CoreWindow.GetForCurrentThread();
-            coreWindow.KeyDown -= CataloguePage_KeyDown;
+            coreWindow.KeyDown -= CoreWindow_KeyDown;
+            coreWindow.SizeChanged -= CoreWindow_SizeChanged;
             var navigator = SystemNavigationManager.GetForCurrentView();
             navigator.BackRequested -= OnBackRequested;
 
@@ -137,13 +139,21 @@ namespace AmbientSounds.Views
             GoBack();
         }
 
-        private void CataloguePage_KeyDown(CoreWindow sender, KeyEventArgs args)
+        private void CoreWindow_KeyDown(CoreWindow sender, KeyEventArgs args)
         {
             if (args.VirtualKey == VirtualKey.Escape)
             {
                 GoBack();
                 args.Handled = true;
             }
+        }
+
+        private void CoreWindow_SizeChanged(CoreWindow sender, WindowSizeChangedEventArgs args)
+        {
+            var view = ApplicationView.GetForCurrentView();
+
+            IsFullscreen = view.IsFullScreenMode;
+            this.Bindings.Update();
         }
 
         private void GoBack()
@@ -195,9 +205,6 @@ namespace AmbientSounds.Views
                     { "name", ViewModel.CurrentSelection?.Text ?? string.Empty }
                 });
             }
-
-            IsFullscreen = view.IsFullScreenMode;
-            this.Bindings.Update();
         }
     }
 }


### PR DESCRIPTION
In the screensaver page, the fullscreen icon in the fullscreen button can get out of sync with the fullscreen state if the user changes the fullscreen state manually. (To reproduce, go to screensaver page, click fullscreen icon, use the exit fullscreen button in system title bar or use command Win + shift + enter to toggle fullscreen, and the icon does not change).

This approach uses the CoreWindow SizeChanged event to detect fullscreen state change per [ApplicationView.TryEnterFullScreenMode Method
](https://docs.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.applicationview.tryenterfullscreenmode)
> The system raises the [CoreWindow.SizeChanged](https://docs.microsoft.com/en-us/uwp/api/windows.ui.core.corewindow.sizechanged) event when the view enters or exits full screen mode.

to detect when the full screen mode is changed, and updates the icon accordingly. The code changing the icon in the button clicked is removed since it is redundant and TryEnterFullScreenMode can fail. It also checks if the app is already in fullscreen so the icon is right when the screensavers are opened.