### PR TITLE
Update ComputeSharp to 2.0.0-alpha.26

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -543,7 +543,7 @@
       <Version>0.0.2-preview</Version>
     </PackageReference>
     <PackageReference Include="ComputeSharp.Uwp">
-      <Version>2.0.0-alpha.19</Version>
+      <Version>2.0.0-alpha.26</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>4.5.1</Version>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -176,11 +176,11 @@ namespace AmbientSounds.Views
             GoBack();
         }
 
-        private void AnimatedComputeShaderPanel_RenderingFailed(AnimatedComputeShaderPanel sender, Exception args)
+        private void AnimatedComputeShaderPanel_RenderingFailed(AnimatedComputeShaderPanel sender, RenderingFailedEventArgs args)
         {
             var telemetry = App.Services.GetRequiredService<ITelemetry>();
 
-            telemetry.TrackError(args, new Dictionary<string, string>()
+            telemetry.TrackError(args.Exception, new Dictionary<string, string>()
             {
                 { "name", ViewModel.AnimatedBackgroundName ?? string.Empty },
             });

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using AmbientSounds.Constants;
 using AmbientSounds.Services;
 using AmbientSounds.ViewModels;
+using ComputeSharp;
 using ComputeSharp.Uwp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
@@ -49,6 +50,8 @@ namespace AmbientSounds.Views
             coreWindow.SizeChanged += CoreWindow_SizeChanged;
             var navigator = SystemNavigationManager.GetForCurrentView();
             navigator.BackRequested += OnBackRequested;
+            var device = GraphicsDevice.GetDefault();
+            device.DeviceLost += Device_DeviceLost;
 
             var view = ApplicationView.GetForCurrentView();
             IsFullscreen = view.IsFullScreenMode;
@@ -69,6 +72,8 @@ namespace AmbientSounds.Views
             coreWindow.SizeChanged -= CoreWindow_SizeChanged;
             var navigator = SystemNavigationManager.GetForCurrentView();
             navigator.BackRequested -= OnBackRequested;
+            var device = GraphicsDevice.GetDefault();
+            device.DeviceLost -= Device_DeviceLost;
 
             SettingsFlyout?.Items?.Clear();
         }
@@ -157,6 +162,16 @@ namespace AmbientSounds.Views
 
             IsFullscreen = view.IsFullScreenMode;
             this.Bindings.Update();
+        }
+
+        private void Device_DeviceLost(object sender, DeviceLostEventArgs e)
+        {
+            var telemetry = App.Services.GetRequiredService<ITelemetry>();
+
+            telemetry.TrackEvent(nameof(GraphicsDevice.DeviceLost), new Dictionary<string, string>()
+            {
+                { "reason", e.Reason.ToString() }
+            });
         }
 
         private void GoBack()

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -168,7 +168,7 @@ namespace AmbientSounds.Views
         {
             var telemetry = App.Services.GetRequiredService<ITelemetry>();
 
-            telemetry.TrackEvent(nameof(GraphicsDevice.DeviceLost), new Dictionary<string, string>()
+            telemetry.TrackEvent(TelemetryConstants.ShaderDeviceLost, new Dictionary<string, string>()
             {
                 { "reason", e.Reason.ToString() }
             });

--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="ComputeSharp" Version="2.0.0-alpha.19" />
+    <PackageReference Include="ComputeSharp" Version="2.0.0-alpha.26" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.cs" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.da" Version="2.14.1" />

--- a/src/AmbientSounds/Constants/TelemetryConstants.cs
+++ b/src/AmbientSounds/Constants/TelemetryConstants.cs
@@ -105,6 +105,7 @@
         // shaders
         private const string Shaders = "shaders:";
         public const string ShaderSelected = Shaders + "selected";
+        public const string ShaderDeviceLost = Shaders + "deviceLost";
 
         public const string MissingSoundsDownloaded = "missingSoundsDownloaded";
         public const string MissingSoundsCanceled = "missingSoundsCanceled";

--- a/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
@@ -155,7 +155,7 @@ namespace AmbientSounds.ViewModels
 
             // Only enable compute shaders on desktop and when not using the WARP device
             if (_systemInfoProvider.IsDesktop() &&
-                GraphicsDevice.Default.IsHardwareAccelerated)
+                GraphicsDevice.GetDefault().IsHardwareAccelerated)
             {
                 // Animated backgrounds
                 MenuItems.Add(new FlyoutMenuItem($"[CS]{nameof(ColorfulInfinity)}", _localizer.GetString("ComputeShader/ColoredSmoke"), screensaverCommand, $"[CS]{nameof(ColorfulInfinity)}", true));


### PR DESCRIPTION
This PR updates ComputeSharp to the latest 2.0.0-alpha.26.
This includes several performance and reliability improvements.

Additionally, this PR also adds a new telemetry event for when the device is lost, including the reason.