### PR TITLE
Switch JSON serialization to System.Text.Json generators

### DIFF
--- a/src/AmbientSounds.Uwp/Properties/Default.rd.xml
+++ b/src/AmbientSounds.Uwp/Properties/Default.rd.xml
@@ -18,20 +18,14 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Application>
 
-      <!-- Required for JSON serialization -->
-      <Type Name="System.Text.Json.JsonSerializer" Serialize="Required All" />
-	  
-      <!-- JSON model types -->
-      <Namespace Name="AmbientSounds.Models" Dynamic="Required Public"/>
-
       <!-- Required for the toolkit's notification helpers to work in release mode -->
       <Assembly Name="Microsoft.Toolkit.Uwp.Notifications" Dynamic="Required All" />
 
-	  <!-- Required for signalr to work in release mode -->
-	  <Namespace Name="Microsoft.Extensions.Options" Dynamic="Required Public"/>
-	  <Type Name="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions" Activate="Required Public" />
-	  <Type Name="Microsoft.Extensions.Logging.LoggerFactoryOptions" Activate="Required Public" />
-	  <Type Name="Microsoft.Extensions.Logging.LoggerFilterOptions" Activate="Required Public" />
-	  <Type Name="Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions" Activate="Required Public" />
+      <!-- Required for signalr to work in release mode -->
+      <Namespace Name="Microsoft.Extensions.Options" Dynamic="Required Public"/>
+      <Type Name="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions" Activate="Required Public" />
+      <Type Name="Microsoft.Extensions.Logging.LoggerFactoryOptions" Activate="Required Public" />
+      <Type Name="Microsoft.Extensions.Logging.LoggerFilterOptions" Activate="Required Public" />
+      <Type Name="Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions" Activate="Required Public" />
   </Application>
 </Directives>

--- a/src/AmbientSounds.Uwp/Services/LocalSettings.cs
+++ b/src/AmbientSounds.Uwp/Services/LocalSettings.cs
@@ -1,6 +1,7 @@
 ﻿using AmbientSounds.Constants;
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Windows.Storage;
 
 #nullable enable
@@ -32,21 +33,21 @@ namespace AmbientSounds.Services.Uwp
         }
 
         /// <inheritdoc/>
-        public T? GetAndDeserialize<T>(string settingKey)
+        public T? GetAndDeserialize<T>(string settingKey, JsonTypeInfo<T> jsonTypeInfo)
         {
             object result = ApplicationData.Current.LocalSettings.Values[settingKey];
             if (result is string serialized)
             {
-                return JsonSerializer.Deserialize<T>(serialized);
+                return JsonSerializer.Deserialize(serialized, jsonTypeInfo);
             }
 
             return (T)UserSettingsConstants.Defaults[settingKey];
         }
 
         /// <inheritdoc/>
-        public void SetAndSerialize<T>(string settingKey, T value)
+        public void SetAndSerialize<T>(string settingKey, T value, JsonTypeInfo<T> jsonTypeInfo)
         {
-            var serialized = JsonSerializer.Serialize(value);
+            var serialized = JsonSerializer.Serialize(value, jsonTypeInfo);
             Set(settingKey, serialized);
         }
 

--- a/src/AmbientSounds.Uwp/Services/SoundDataProvider.cs
+++ b/src/AmbientSounds.Uwp/Services/SoundDataProvider.cs
@@ -187,7 +187,7 @@ namespace AmbientSounds.Services.Uwp
             StorageFile localDataFile = await ApplicationData.Current.LocalFolder.CreateFileAsync(
                 LocalDataFileName,
                 CreationCollisionOption.OpenIfExists);
-            string json = JsonSerializer.Serialize(_localSoundCache);
+            string json = _localSoundCache is null ? "" : JsonSerializer.Serialize(_localSoundCache, AmbieJsonSerializerContext.Default.ListSound);
             await FileIO.WriteTextAsync(localDataFile, json);
         }
 
@@ -210,7 +210,7 @@ namespace AmbientSounds.Services.Uwp
             try
             {
                 using Stream dataStream = await localDataFile.OpenStreamForReadAsync();
-                _localSoundCache = await JsonSerializer.DeserializeAsync<List<Sound>>(dataStream);
+                _localSoundCache = await JsonSerializer.DeserializeAsync(dataStream, AmbieJsonSerializerContext.Default.ListSound);
             }
             catch (Exception)
             {
@@ -233,7 +233,7 @@ namespace AmbientSounds.Services.Uwp
                 StorageFolder assets = await appInstalledFolder.GetFolderAsync("Assets");
                 StorageFile dataFile = await assets.GetFileAsync(DataFileName);
                 using Stream dataStream = await dataFile.OpenStreamForReadAsync();
-                var sounds = await JsonSerializer.DeserializeAsync<List<Sound>>(dataStream);
+                var sounds = await JsonSerializer.DeserializeAsync(dataStream, AmbieJsonSerializerContext.Default.ListSound);
 
                 foreach (var s in sounds!)
                 {

--- a/src/AmbientSounds.Uwp/Views/ShellPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ShellPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AmbientSounds.Constants;
+using AmbientSounds.Models;
 using AmbientSounds.Services;
 using AmbientSounds.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +75,8 @@ namespace AmbientSounds.Views
             ViewModel.IsRatingMessageVisible = false;
             App.Services.GetRequiredService<IUserSettings>().SetAndSerialize(
                 UserSettingsConstants.RatingDismissed,
-                DateTime.UtcNow);
+                DateTime.UtcNow,
+                AmbieJsonSerializerContext.Default.DateTime);
             App.Services.GetRequiredService<ITelemetry>().TrackEvent(TelemetryConstants.OobeRateUsDismissed);
         }
 

--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="PolySharp" Version="1.3.0" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0-rc.2.22472.3" />
   </ItemGroup>
 
   <!-- MSBuild properties to customize the generation from PolySharp -->

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -12,6 +12,7 @@ namespace AmbientSounds.Models
     [JsonSerializable(typeof(IEnumerable<FocusTask>))]
     [JsonSerializable(typeof(Video[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
     [JsonSerializable(typeof(IList<Video>))]
+    [JsonSerializable(typeof(SyncData))]
     public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
     {
     }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -1,22 +1,38 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace AmbientSounds.Models
+namespace AmbientSounds.Models;
+
+/// <summary>
+/// The <see cref="JsonSerializerContext"/> with type info for all JSON models used by Ambie.
+/// </summary>
+[JsonSerializable(typeof(FocusHistory))]
+[JsonSerializable(typeof(FocusHistorySummary))]
+[JsonSerializable(typeof(FocusTask[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+[JsonSerializable(typeof(IEnumerable<FocusTask>))]
+[JsonSerializable(typeof(Video[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+[JsonSerializable(typeof(IList<Video>))]
+[JsonSerializable(typeof(SyncData))]
+[JsonSerializable(typeof(Sound[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+[JsonSerializable(typeof(List<Sound>))]
+[JsonSerializable(typeof(RecentFocusSettings[]))]
+public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
 {
-    /// <summary>
-    /// The <see cref="JsonSerializerContext"/> with type info for all JSON models used by Ambie.
-    /// </summary>
-    [JsonSerializable(typeof(FocusHistory))]
-    [JsonSerializable(typeof(FocusHistorySummary))]
-    [JsonSerializable(typeof(FocusTask[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
-    [JsonSerializable(typeof(IEnumerable<FocusTask>))]
-    [JsonSerializable(typeof(Video[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
-    [JsonSerializable(typeof(IList<Video>))]
-    [JsonSerializable(typeof(SyncData))]
-    [JsonSerializable(typeof(Sound[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
-    [JsonSerializable(typeof(List<Sound>))]
-    [JsonSerializable(typeof(RecentFocusSettings[]))]
-    public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
-    {
-    }
+    // This type acts as the receiver for the System.Text.Json generator to generate all the JSON serialization
+    // code for the types marked as annotations here. That is, instead of using runtime reflection, the generator
+    // will generate all the necessary serialization code at build time, so that all the code can be trimmed and
+    // also run faster at runtime. See: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation.
+    //
+    // There are two types of annotations used here, primarily:
+    //   - Types that are only deserialized are marked with JsonSourceGenerationMode.Metadata. This is only a subset of the
+    //     code that's possible to generate, and it won't include the deserialization code, as that's not needed.
+    //   - Types that are both serialized and deserialized just use the default setting, which include both modes.
+    //
+    // If you add a new type that needs to use JSON serialization, make sure to add an attribute here. Then to serialize:
+    //
+    // Do NOT do this as before: JsonSerializer.Serialize(myModel);
+    //
+    // Do THIS instead:          JsonSerializer.Serialize(myModel, AmbieJsonSerializerContext.Default.MyModel);
+    //
+    // That is, pass the generated JsonTypeInfo<T> property that matches that model type. Same to deserialize.
 }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -15,6 +15,7 @@ namespace AmbientSounds.Models
     [JsonSerializable(typeof(SyncData))]
     [JsonSerializable(typeof(Sound[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
     [JsonSerializable(typeof(List<Sound>))]
+    [JsonSerializable(typeof(RecentFocusSettings[]))]
     public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
     {
     }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -10,6 +10,8 @@ namespace AmbientSounds.Models
     [JsonSerializable(typeof(FocusHistorySummary))]
     [JsonSerializable(typeof(FocusTask[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
     [JsonSerializable(typeof(IEnumerable<FocusTask>))]
+    [JsonSerializable(typeof(Video[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+    [JsonSerializable(typeof(IList<Video>))]
     public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
     {
     }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -13,6 +13,8 @@ namespace AmbientSounds.Models
     [JsonSerializable(typeof(Video[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
     [JsonSerializable(typeof(IList<Video>))]
     [JsonSerializable(typeof(SyncData))]
+    [JsonSerializable(typeof(Sound[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+    [JsonSerializable(typeof(List<Sound>))]
     public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
     {
     }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace AmbientSounds.Models;
@@ -6,6 +7,37 @@ namespace AmbientSounds.Models;
 /// <summary>
 /// The <see cref="JsonSerializerContext"/> with type info for all JSON models used by Ambie.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This type acts as the receiver for the System.Text.Json generator to generate all the JSON serialization
+/// code for the types marked as annotations here. That is, instead of using runtime reflection, the generator
+/// will generate all the necessary serialization code at build time, so that all the code can be trimmed and
+/// also run faster at runtime. See: <see href="https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation"/>.
+/// </para>
+/// <para>
+/// There are two types of annotations used here, primarily:
+/// <list type="bullet">
+///   <item>
+///     Types that are only deserialized are marked with JsonSourceGenerationMode.Metadata. This is only a subset of the
+///     code that's possible to generate, and it won't include the deserialization code, as that's not needed.  
+///   </item>
+///   <item>Types that are both serialized and deserialized just use the default setting, which include both modes.</item>
+/// </list>
+/// </para>
+/// <para>
+/// If you add a new type that needs to use JSON serialization, make sure to add an attribute here. Then to serialize:
+/// <code>
+/// Do NOT do this as before:
+/// JsonSerializer.Serialize(myModel);
+/// 
+/// // Do THIS instead:
+/// JsonSerializer.Serialize(myModel, AmbieJsonSerializerContext.Default.MyModel);
+/// </code>
+/// </para>
+/// <para>
+/// That is, pass the generated <see cref="System.Text.Json.Serialization.Metadata.JsonTypeInfo{T}"/> property that matches that model type. Same to deserialize.
+/// </para>
+/// </remarks>
 [JsonSerializable(typeof(FocusHistory))]
 [JsonSerializable(typeof(FocusHistorySummary))]
 [JsonSerializable(typeof(FocusTask[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
@@ -18,21 +50,4 @@ namespace AmbientSounds.Models;
 [JsonSerializable(typeof(RecentFocusSettings[]))]
 public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
 {
-    // This type acts as the receiver for the System.Text.Json generator to generate all the JSON serialization
-    // code for the types marked as annotations here. That is, instead of using runtime reflection, the generator
-    // will generate all the necessary serialization code at build time, so that all the code can be trimmed and
-    // also run faster at runtime. See: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation.
-    //
-    // There are two types of annotations used here, primarily:
-    //   - Types that are only deserialized are marked with JsonSourceGenerationMode.Metadata. This is only a subset of the
-    //     code that's possible to generate, and it won't include the deserialization code, as that's not needed.
-    //   - Types that are both serialized and deserialized just use the default setting, which include both modes.
-    //
-    // If you add a new type that needs to use JSON serialization, make sure to add an attribute here. Then to serialize:
-    //
-    // Do NOT do this as before: JsonSerializer.Serialize(myModel);
-    //
-    // Do THIS instead:          JsonSerializer.Serialize(myModel, AmbieJsonSerializerContext.Default.MyModel);
-    //
-    // That is, pass the generated JsonTypeInfo<T> property that matches that model type. Same to deserialize.
 }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AmbientSounds.Models
+{
+    /// <summary>
+    /// The <see cref="JsonSerializerContext"/> with type info for all JSON models used by Ambie.
+    /// </summary>
+    [JsonSerializable(typeof(FocusHistory))]
+    [JsonSerializable(typeof(FocusHistorySummary))]
+    public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -50,4 +50,13 @@ namespace AmbientSounds.Models;
 [JsonSerializable(typeof(RecentFocusSettings[]))]
 public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
 {
+    /// <summary>
+    /// The lazily initialized backing field for the context to be used for case insensitive serialization (<see cref="CaseInsensitive"/>).
+    /// </summary>
+    private static AmbieJsonSerializerContext? _caseInsensitive;
+
+    /// <summary>
+    /// A case insensitive variant of <see cref="Default"/>.
+    /// </summary>
+    public static AmbieJsonSerializerContext CaseInsensitive => _caseInsensitive ??= new AmbieJsonSerializerContext(new JsonSerializerOptions(s_defaultOptions) { PropertyNameCaseInsensitive = true });
 }

--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace AmbientSounds.Models
 {
@@ -7,6 +8,8 @@ namespace AmbientSounds.Models
     /// </summary>
     [JsonSerializable(typeof(FocusHistory))]
     [JsonSerializable(typeof(FocusHistorySummary))]
+    [JsonSerializable(typeof(FocusTask[]), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
+    [JsonSerializable(typeof(IEnumerable<FocusTask>))]
     public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
     {
     }

--- a/src/AmbientSounds/Models/FocusHistory.cs
+++ b/src/AmbientSounds/Models/FocusHistory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace AmbientSounds.Models
 {
@@ -27,6 +28,7 @@ namespace AmbientSounds.Models
         /// </summary>
         public long PartialSegmentTicks { get; set; }
 
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public SessionType PartialSegmentType { get; set; }
 
         public List<FocusInterruption> Interruptions { get; set; } = new();

--- a/src/AmbientSounds/Repositories/FocusHistoryRepository.cs
+++ b/src/AmbientSounds/Repositories/FocusHistoryRepository.cs
@@ -32,7 +32,7 @@ namespace AmbientSounds.Repositories
 
             try
             {
-                var result = JsonSerializer.Deserialize<FocusHistory>(content);
+                var result = JsonSerializer.Deserialize(content, AmbieJsonSerializerContext.Default.FocusHistory);
                 return result;
             }
             catch
@@ -51,7 +51,7 @@ namespace AmbientSounds.Repositories
 
             try
             {
-                var result = JsonSerializer.Deserialize<FocusHistorySummary>(content);
+                var result = JsonSerializer.Deserialize(content, AmbieJsonSerializerContext.Default.FocusHistorySummary);
                 return result ?? new FocusHistorySummary();
             }
             catch
@@ -62,12 +62,12 @@ namespace AmbientSounds.Repositories
 
         public Task SaveHistoryAsync(FocusHistory history)
         {
-            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(history), HistoryPath(history.StartUtcTicks));
+            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(history, AmbieJsonSerializerContext.Default.FocusHistory), HistoryPath(history.StartUtcTicks));
         }
 
         public Task SaveSummaryAsync(FocusHistorySummary summary)
         {
-            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(summary), SummaryFileName);
+            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(summary, AmbieJsonSerializerContext.Default.FocusHistorySummary), SummaryFileName);
         }
     }
 }

--- a/src/AmbientSounds/Repositories/FocusTaskRepository.cs
+++ b/src/AmbientSounds/Repositories/FocusTaskRepository.cs
@@ -30,7 +30,7 @@ namespace AmbientSounds.Repositories
 
             try
             {
-                var result = JsonSerializer.Deserialize<FocusTask[]>(content);
+                var result = JsonSerializer.Deserialize(content, AmbieJsonSerializerContext.Default.FocusTaskArray);
                 return result ?? Array.Empty<FocusTask>();
             }
             catch
@@ -47,7 +47,7 @@ namespace AmbientSounds.Repositories
                 return;
             }
 
-            await _fileWriter.WriteStringAsync(JsonSerializer.Serialize(tasks), TasksFilename);
+            await _fileWriter.WriteStringAsync(JsonSerializer.Serialize(tasks, AmbieJsonSerializerContext.Default.IEnumerableFocusTask), TasksFilename);
         }
     }
 }

--- a/src/AmbientSounds/Repositories/OfflineVideoRepository.cs
+++ b/src/AmbientSounds/Repositories/OfflineVideoRepository.cs
@@ -33,7 +33,7 @@ namespace AmbientSounds.Repositories
 
             try
             {
-                var result = JsonSerializer.Deserialize<Video[]>(content);
+                var result = JsonSerializer.Deserialize(content, AmbieJsonSerializerContext.Default.VideoArray);
                 return result ?? Array.Empty<Video>();
             }
             catch
@@ -45,7 +45,7 @@ namespace AmbientSounds.Repositories
         /// <inheritdoc/>
         public Task SaveVideosAsync(IList<Video> videos)
         {
-            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(videos), LocalVideoDataFile);
+            return _fileWriter.WriteStringAsync(JsonSerializer.Serialize(videos, AmbieJsonSerializerContext.Default.IListVideo), LocalVideoDataFile);
         }
     }
 }

--- a/src/AmbientSounds/Repositories/OnlineVideoRepository.cs
+++ b/src/AmbientSounds/Repositories/OnlineVideoRepository.cs
@@ -14,10 +14,6 @@ namespace AmbientSounds.Repositories
     {
         private readonly string _videosUrl;
         private readonly HttpClient _client;
-        private readonly AmbieJsonSerializerContext _deserializeContext = new(new JsonSerializerOptions()
-        {
-            PropertyNameCaseInsensitive = true
-        });
 
         public OnlineVideoRepository(
             HttpClient httpClient,
@@ -36,7 +32,7 @@ namespace AmbientSounds.Repositories
             {
                 using Stream result = await _client.GetStreamAsync(_videosUrl);
 
-                var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.VideoArray);
+                var results = await JsonSerializer.DeserializeAsync(result, AmbieJsonSerializerContext.CaseInsensitive.VideoArray);
 
                 return results ?? Array.Empty<Video>();
             }
@@ -55,7 +51,7 @@ namespace AmbientSounds.Repositories
                 if (result.IsSuccessStatusCode)
                 {
                     var json = await result.Content.ReadAsStringAsync();
-                    var video = JsonSerializer.Deserialize(json, _deserializeContext.Video);
+                    var video = JsonSerializer.Deserialize(json, AmbieJsonSerializerContext.CaseInsensitive.Video);
                     return video?.DownloadUrl ?? string.Empty;
                 }
             }

--- a/src/AmbientSounds/Repositories/OnlineVideoRepository.cs
+++ b/src/AmbientSounds/Repositories/OnlineVideoRepository.cs
@@ -14,10 +14,10 @@ namespace AmbientSounds.Repositories
     {
         private readonly string _videosUrl;
         private readonly HttpClient _client;
-        private readonly JsonSerializerOptions _deserializeOptions = new JsonSerializerOptions()
+        private readonly AmbieJsonSerializerContext _deserializeContext = new(new JsonSerializerOptions()
         {
             PropertyNameCaseInsensitive = true
-        };
+        });
 
         public OnlineVideoRepository(
             HttpClient httpClient,
@@ -35,7 +35,8 @@ namespace AmbientSounds.Repositories
             try
             {
                 using Stream result = await _client.GetStreamAsync(_videosUrl);
-                var results = await JsonSerializer.DeserializeAsync<Video[]>(result, _deserializeOptions);
+
+                var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.VideoArray);
 
                 return results ?? Array.Empty<Video>();
             }
@@ -54,7 +55,7 @@ namespace AmbientSounds.Repositories
                 if (result.IsSuccessStatusCode)
                 {
                     var json = await result.Content.ReadAsStringAsync();
-                    var video = JsonSerializer.Deserialize<Video>(json, _deserializeOptions);
+                    var video = JsonSerializer.Deserialize(json, _deserializeContext.Video);
                     return video?.DownloadUrl ?? string.Empty;
                 }
             }

--- a/src/AmbientSounds/Services/IUserSettings.cs
+++ b/src/AmbientSounds/Services/IUserSettings.cs
@@ -1,5 +1,6 @@
 ﻿using AmbientSounds.Constants;
 using System;
+using System.Text.Json.Serialization.Metadata;
 
 namespace AmbientSounds.Services
 {
@@ -46,8 +47,9 @@ namespace AmbientSounds.Services
         /// </summary>
         /// <typeparam name="T">Type of the value.</typeparam>
         /// <param name="settingKey">The settings key, generally found in <see cref="UserSettingsConstants"/>.</param>
+        /// <param name="jsonTypeInfo">The <see cref="JsonTypeInfo{T}"/> instance to deserialize <typeparamref name="T"/> values.</param>
         /// <returns>The desired value or returns the default.</returns>
-        T? GetAndDeserialize<T>(string settingKey);
+        T? GetAndDeserialize<T>(string settingKey, JsonTypeInfo<T> jsonTypeInfo);
 
         /// <summary>
         /// Saves settings into persistent local storage
@@ -56,6 +58,7 @@ namespace AmbientSounds.Services
         /// <typeparam name="T">Type of the value.</typeparam>
         /// <param name="settingKey">The settings key, generally found in <see cref="UserSettingsConstants"/>.</param>
         /// <param name="value">The value to save.</param>
-        void SetAndSerialize<T>(string settingKey, T value);
+        /// <param name="jsonTypeInfo">The <see cref="JsonTypeInfo{T}"/> instance to serialize <typeparamref name="T"/> values.</param>
+        void SetAndSerialize<T>(string settingKey, T value, JsonTypeInfo<T> jsonTypeInfo);
     }
 }

--- a/src/AmbientSounds/Services/OnlineSoundDataProvider.cs
+++ b/src/AmbientSounds/Services/OnlineSoundDataProvider.cs
@@ -21,11 +21,6 @@ namespace AmbientSounds.Services
         private readonly string _url;
         private readonly string _mySoundsUrl;
 
-        private readonly AmbieJsonSerializerContext _deserializeContext = new(new JsonSerializerOptions()
-        {
-            PropertyNameCaseInsensitive = true
-        });
-
         /// <inheritdoc/>
         public event EventHandler<int>? UserSoundsFetched;
 
@@ -73,7 +68,7 @@ namespace AmbientSounds.Services
 
             var url = _url + $"?culture={_systemInfoProvider.GetCulture()}&premium=true";
             using Stream result = await _client.GetStreamAsync(url);
-            var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.SoundArray);
+            var results = await JsonSerializer.DeserializeAsync(result, AmbieJsonSerializerContext.CaseInsensitive.SoundArray);
 
             return results ?? Array.Empty<Sound>();
         }
@@ -130,7 +125,7 @@ namespace AmbientSounds.Services
 
             try
             {
-                var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.SoundArray);
+                var results = await JsonSerializer.DeserializeAsync(result, AmbieJsonSerializerContext.CaseInsensitive.SoundArray);
 
                 UserSoundsFetched?.Invoke(this, results?.Length ?? 0);
                 return results ?? Array.Empty<Sound>();

--- a/src/AmbientSounds/Services/OnlineSoundDataProvider.cs
+++ b/src/AmbientSounds/Services/OnlineSoundDataProvider.cs
@@ -21,6 +21,11 @@ namespace AmbientSounds.Services
         private readonly string _url;
         private readonly string _mySoundsUrl;
 
+        private readonly AmbieJsonSerializerContext _deserializeContext = new(new JsonSerializerOptions()
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
         /// <inheritdoc/>
         public event EventHandler<int>? UserSoundsFetched;
 
@@ -68,9 +73,7 @@ namespace AmbientSounds.Services
 
             var url = _url + $"?culture={_systemInfoProvider.GetCulture()}&premium=true";
             using Stream result = await _client.GetStreamAsync(url);
-            var results = await JsonSerializer.DeserializeAsync<Sound[]>(
-                result,
-                new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+            var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.SoundArray);
 
             return results ?? Array.Empty<Sound>();
         }
@@ -127,9 +130,7 @@ namespace AmbientSounds.Services
 
             try
             {
-                var results = await JsonSerializer.DeserializeAsync<Sound[]>(
-                    result,
-                    new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+                var results = await JsonSerializer.DeserializeAsync(result, _deserializeContext.SoundArray);
 
                 UserSoundsFetched?.Invoke(this, results?.Length ?? 0);
                 return results ?? Array.Empty<Sound>();

--- a/src/AmbientSounds/Services/RecentFocusService.cs
+++ b/src/AmbientSounds/Services/RecentFocusService.cs
@@ -59,7 +59,7 @@ namespace AmbientSounds.Services
             }
 
             _cache.TryAdd(settings.LastUsed.Ticks, settings);
-            _userSettings.SetAndSerialize(UserSettingsConstants.RecentFocusKey, _cache.Values.ToArray());
+            _userSettings.SetAndSerialize(UserSettingsConstants.RecentFocusKey, _cache.Values.ToArray(), AmbieJsonSerializerContext.Default.RecentFocusSettingsArray);
 
             foreach (var key in _cache.Keys)
             {
@@ -84,7 +84,7 @@ namespace AmbientSounds.Services
             if (_cache is null)
             {
                 _cache = new();
-                var storedFocusSettings = _userSettings.GetAndDeserialize<RecentFocusSettings[]>(UserSettingsConstants.RecentFocusKey)
+                var storedFocusSettings = _userSettings.GetAndDeserialize(UserSettingsConstants.RecentFocusKey, AmbieJsonSerializerContext.Default.RecentFocusSettingsArray)
                     ?? Array.Empty<RecentFocusSettings>();
 
                 foreach (var settings in storedFocusSettings)

--- a/src/AmbientSounds/Services/SyncEngine.cs
+++ b/src/AmbientSounds/Services/SyncEngine.cs
@@ -154,7 +154,7 @@ namespace AmbientSounds.Services
             try
             {
                 string serialized = await _cloudFileWriter.ReadFileAsync(_cloudSyncFileUrl, token, default);
-                data = JsonSerializer.Deserialize<SyncData>(serialized);
+                data = JsonSerializer.Deserialize(serialized, AmbieJsonSerializerContext.Default.SyncData);
             }
             catch
             {
@@ -232,7 +232,7 @@ namespace AmbientSounds.Services
                     .ToArray()
             };
 
-            var serialized = JsonSerializer.Serialize(syncData);
+            var serialized = JsonSerializer.Serialize(syncData, AmbieJsonSerializerContext.Default.SyncData);
 
             try
             {

--- a/src/AmbientSounds/ViewModels/ActiveTrackListViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ActiveTrackListViewModel.cs
@@ -122,7 +122,7 @@ namespace AmbientSounds.ViewModels
                 // This case is when the app is being launched.
 
                 var mixId = _userSettings.Get<string>(UserSettingsConstants.ActiveMixId);
-                var previousActiveTrackIds = _userSettings.GetAndDeserialize<string[]>(UserSettingsConstants.ActiveTracks);
+                var previousActiveTrackIds = _userSettings.GetAndDeserialize(UserSettingsConstants.ActiveTracks, AmbieJsonSerializerContext.Default.StringArray);
                 var sounds = await _soundDataProvider.GetSoundsAsync(soundIds: previousActiveTrackIds);
                 if (sounds is not null && sounds.Count > 0)
                 {
@@ -167,7 +167,7 @@ namespace AmbientSounds.ViewModels
         private void UpdateStoredState()
         {
             var ids = ActiveTracks.Select(static x => x.Sound.Id).ToArray();
-            _userSettings.SetAndSerialize(UserSettingsConstants.ActiveTracks, ids);
+            _userSettings.SetAndSerialize(UserSettingsConstants.ActiveTracks, ids, AmbieJsonSerializerContext.Default.StringArray);
             _userSettings.Set(UserSettingsConstants.ActiveMixId, _player.CurrentMixId);
         }
 

--- a/src/AmbientSounds/ViewModels/ShellPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ShellPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using AmbientSounds.Constants;
+using AmbientSounds.Models;
 using AmbientSounds.Services;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -58,7 +59,7 @@ namespace AmbientSounds.ViewModels
             _focusService = focusService;
             _soundMixService = soundMixService;
 
-            var lastDismissDateTime = _userSettings.GetAndDeserialize<DateTime>(UserSettingsConstants.RatingDismissed);
+            var lastDismissDateTime = _userSettings.GetAndDeserialize(UserSettingsConstants.RatingDismissed, AmbieJsonSerializerContext.Default.DateTime);
             if (!systemInfoProvider.IsFirstRun() &&
                 !systemInfoProvider.IsTenFoot() &&
                 !_userSettings.Get<bool>(UserSettingsConstants.HasRated) &&


### PR DESCRIPTION
This PR switches all JSON serialization using System.Text.Json to use source generators. This makes the serialization completely trimming-friendly, and also much faster, as it completely removes the need for reflection at runtime to generate metadata.