### PR TITLE
Enable trimming in Microsoft.Toolkit.Notifications again

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -656,25 +656,25 @@
       <Version>10.1901.28001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Behaviors">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Media">
-      <Version>7.1.2</Version>
+      <Version>7.1.3-rc</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.7.1</Version>

--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -656,25 +656,25 @@
       <Version>10.1901.28001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Behaviors">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Media">
-      <Version>7.1.3-rc</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.7.1</Version>

--- a/src/AmbientSounds.Uwp/Properties/Default.rd.xml
+++ b/src/AmbientSounds.Uwp/Properties/Default.rd.xml
@@ -18,14 +18,11 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Application>
 
-      <!-- Required for the toolkit's notification helpers to work in release mode -->
-      <Assembly Name="Microsoft.Toolkit.Uwp.Notifications" Dynamic="Required All" />
-
-      <!-- Required for signalr to work in release mode -->
-      <Namespace Name="Microsoft.Extensions.Options" Dynamic="Required Public"/>
-      <Type Name="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions" Activate="Required Public" />
-      <Type Name="Microsoft.Extensions.Logging.LoggerFactoryOptions" Activate="Required Public" />
-      <Type Name="Microsoft.Extensions.Logging.LoggerFilterOptions" Activate="Required Public" />
-      <Type Name="Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions" Activate="Required Public" />
+    <!-- Required for signalr to work in release mode -->
+    <Namespace Name="Microsoft.Extensions.Options" Dynamic="Required Public"/>
+    <Type Name="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions" Activate="Required Public" />
+    <Type Name="Microsoft.Extensions.Logging.LoggerFactoryOptions" Activate="Required Public" />
+    <Type Name="Microsoft.Extensions.Logging.LoggerFilterOptions" Activate="Required Public" />
+    <Type Name="Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions" Activate="Required Public" />
   </Application>
 </Directives>


### PR DESCRIPTION
This PR bumps the Windows Community Toolkit to 7.1.3 and enables trimming again for the notifications. This is thanks to a fix I did in https://github.com/CommunityToolkit/WindowsCommunityToolkit/pull/4553 which completely removed reflection from that package, so trimming is now safe. Leaving this as a PR for now so you can also test this on your end. Will publish as soon as 7.1.3 is released as stable (should be later this week or the next).