### PR TITLE
Bump ComputeSharp packages to 2.0.3

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -632,7 +632,7 @@
       <Version>0.0.3-preview</Version>
     </PackageReference>
     <PackageReference Include="ComputeSharp.Uwp">
-      <Version>2.0.0-alpha.26</Version>
+      <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>4.5.1</Version>

--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="CommunityToolkit.Common" Version="8.0.0" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <PackageReference Include="ComputeSharp" Version="2.0.0-alpha.26" />
+    <PackageReference Include="ComputeSharp" Version="2.0.3" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.cs" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.da" Version="2.14.1" />


### PR DESCRIPTION
### Fixes #303

This PR updates ComputeSharp to the latest stable release, which includes the fix for WARP devices.