### PR TITLE
Switch JSON serialization in MsalClient to System.Text.Json

### DIFF
--- a/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
+++ b/src/AmbientSounds/Models/AmbieJsonSerializerContext.cs
@@ -49,6 +49,7 @@ namespace AmbientSounds.Models;
 [JsonSerializable(typeof(List<Sound>))]
 [JsonSerializable(typeof(IList<Sound>))]
 [JsonSerializable(typeof(RecentFocusSettings[]))]
+[JsonSerializable(typeof(MsalUser), GenerationMode = JsonSourceGenerationMode.Metadata)] // Only used to deserialize
 public sealed partial class AmbieJsonSerializerContext : JsonSerializerContext
 {
     /// <summary>

--- a/src/AmbientSounds/Models/MsalUser.cs
+++ b/src/AmbientSounds/Models/MsalUser.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AmbientSounds.Models;
+
+/// <summary>
+/// A model for a MSA user retrieved from Microsoft Graph.
+/// </summary>
+public sealed record MsalUser(
+    [property: JsonPropertyName("givenName"), JsonRequired] string FirstName,
+    [property: JsonPropertyName("userPrincipalName"), JsonRequired] string Email);


### PR DESCRIPTION
This PR switches the JSON serializatio in `MsalClient` to use System.Text.Json.
Didn't test this locally (not sure how to trigger this path), so just give it a go before merging 😄