### PR TITLE
Add support to choose output audio device

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -268,6 +268,7 @@
     </Compile>
     <Compile Include="Services\AppServiceController.cs" />
     <Compile Include="Services\AppSettings.cs" />
+    <Compile Include="Services\AudioDeviceService.cs" />
     <Compile Include="Services\BackgroundDownloadService.cs" />
     <Compile Include="Services\CompactNavigator.cs" />
     <Compile Include="Services\CustomAuthUiService.cs" />
@@ -736,7 +737,7 @@
   <ItemGroup>
     <PRIResource Include="Strings\en-US\Resources.resw">
       <SubType>Designer</SubType>
-      <Generator>ReswPlusGenerator</Generator>
+      <Generator>ReswPlusAdvancedGenerator</Generator>
       <LastGenOutput>Resources.generated.cs</LastGenOutput>
     </PRIResource>
     <PRIResource Include="Strings\ko-KR\Resources.resw">

--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -737,7 +737,7 @@
   <ItemGroup>
     <PRIResource Include="Strings\en-US\Resources.resw">
       <SubType>Designer</SubType>
-      <Generator>ReswPlusAdvancedGenerator</Generator>
+      <Generator>ReswPlusGenerator</Generator>
       <LastGenOutput>Resources.generated.cs</LastGenOutput>
     </PRIResource>
     <PRIResource Include="Strings\ko-KR\Resources.resw">

--- a/src/AmbientSounds.Uwp/App.xaml
+++ b/src/AmbientSounds.Uwp/App.xaml
@@ -248,6 +248,7 @@
             <x:String x:Key="GlyphCheckMarkCircle">&#xE9A2;</x:String>
             <x:String x:Key="GlyphGripper">&#xEB34;</x:String>
             <x:String x:Key="GlyphUpdates">&#xE91C;</x:String>
+            <x:String x:Key="GlyphAudioDevice">&#xEB82;</x:String>
 
             <x:Double x:Key="NarrowWindowBreakpoint">540</x:Double>
         </ResourceDictionary>

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -486,8 +486,9 @@ namespace AmbientSounds
                 .AddSingleton<IOnlineSoundRepository, OnlineSoundRepository>()
                 .AddSingleton<ISystemInfoProvider, SystemInfoProvider>()
                 .AddSingleton<IAssetsReader, AssetsReader>()
-                .AddSingleton<IMixMediaPlayerService, Services.MixMediaPlayerService>()
+                .AddSingleton<IMixMediaPlayerService, MixMediaPlayerService>()
                 .AddSingleton<ISystemMediaControls, WindowsSystemMediaControls>()
+                .AddSingleton<IAudioDeviceService, AudioDeviceService>()
                 .AddSingleton<IMediaPlayerFactory, WindowsMediaPlayerFactory>()
                 .AddSingleton(appsettings ?? new AppSettings())
                 .BuildServiceProvider(true);

--- a/src/AmbientSounds.Uwp/Controls/SettingsControl.xaml
+++ b/src/AmbientSounds.Uwp/Controls/SettingsControl.xaml
@@ -29,7 +29,7 @@
                 <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="{StaticResource GlyphPaintBrush}" />
             </labs:SettingsCard.HeaderIcon>
 
-            <ComboBox SelectedIndex="{x:Bind ViewModel.CurrentThemeIndex, Mode=OneWay}" SelectionChanged="OnSelectionChanged">
+            <ComboBox SelectedIndex="{x:Bind ViewModel.CurrentThemeIndex, Mode=OneWay}" SelectionChanged="OnThemeSelectionChanged">
                 <ComboBoxItem x:Uid="SettingsThemeDefaultRadio" Tag="default" />
                 <ComboBoxItem x:Uid="SettingsThemeDarkRadio" Tag="dark" />
                 <ComboBoxItem x:Uid="SettingsThemeLightRadio" Tag="light" />
@@ -138,6 +138,24 @@
             </ToggleSwitch>
         </labs:SettingsCard>
 
+        <!--  Audio device selector  -->
+        <labs:SettingsCard Description="{x:Bind strings:Resources.SettingsOutputDeviceDescription}" Header="{x:Bind strings:Resources.SettingsOutputDevice}">
+            <interactivity:Interaction.Behaviors>
+                <core:EventTriggerBehavior EventName="Loaded">
+                    <core:InvokeCommandAction Command="{x:Bind ViewModel.LoadOutputDevicesCommand}" />
+                </core:EventTriggerBehavior>
+            </interactivity:Interaction.Behaviors>
+
+            <labs:SettingsCard.HeaderIcon>
+                <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="{StaticResource GlyphAudioDevice}" />
+            </labs:SettingsCard.HeaderIcon>
+
+            <ComboBox
+                DisplayMemberPath="DeviceName"
+                ItemsSource="{x:Bind ViewModel.OutputDevices}"
+                SelectedItem="{x:Bind ViewModel.CurrentOutputDevice, Mode=TwoWay}" />
+        </labs:SettingsCard>
+
         <!--  Ambie Mini on focus  -->
         <labs:SettingsCard Description="{x:Bind strings:Resources.SettingsCompactModeDescription}" Header="{x:Bind strings:Resources.SettingsCompactMode}">
             <labs:SettingsCard.HeaderIcon>
@@ -159,11 +177,11 @@
                 <TextBlock Text="© Jenius Apps" />
             </labs:SettingsExpander.Description>
             <labs:SettingsExpander.HeaderIcon>
-                <BitmapIcon UriSource="ms-appx:///Assets/logo.png" ShowAsMonochrome="False"/>
+                <BitmapIcon ShowAsMonochrome="False" UriSource="ms-appx:///Assets/logo.png" />
             </labs:SettingsExpander.HeaderIcon>
             <TextBlock
-                IsTextSelectionEnabled="True"
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                IsTextSelectionEnabled="True"
                 Style="{StaticResource CaptionTextBlockStyle}"
                 Text="{x:Bind Version}" />
             <labs:SettingsExpander.Items>

--- a/src/AmbientSounds.Uwp/Controls/SettingsControl.xaml.cs
+++ b/src/AmbientSounds.Uwp/Controls/SettingsControl.xaml.cs
@@ -27,7 +27,7 @@ namespace AmbientSounds.Controls
             }
         }
 
-        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void OnThemeSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.AddedItems is [ComboBoxItem c, ..] && c.Tag is string s)
             {

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.bg.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.bg.xlf
@@ -980,6 +980,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Имате нужда от помощ при прекъсвания?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.cs-CZ.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.cs-CZ.xlf
@@ -984,6 +984,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Potřebujete pomoc s vyrušováním?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.da-DK.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.da-DK.xlf
@@ -989,6 +989,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Har du brug for hjælp til afbrydelser?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.de-DE.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.de-DE.xlf
@@ -985,6 +985,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Benötigen Sie Hilfe bei Unterbrechungen?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.el.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.el.xlf
@@ -980,6 +980,14 @@
           <source>Need help with interruptions?</source>
           <target state="new">Need help with interruptions?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.es-ES.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.es-ES.xlf
@@ -987,6 +987,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">¿Necesita ayuda con las interrupciones?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.fa-IR.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.fa-IR.xlf
@@ -980,6 +980,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">برای وقفه ها به کمک نیاز دارید؟</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.fr-FR.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.fr-FR.xlf
@@ -993,6 +993,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Besoin d’aide en cas d’interruption?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.he-IL.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.he-IL.xlf
@@ -983,6 +983,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">זקוק לעזרה עם הפרעות?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hr-HR.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hr-HR.xlf
@@ -987,6 +987,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Trebate pomoć s prekidima?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hu-HU.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.hu-HU.xlf
@@ -994,6 +994,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Segítségre van szüksége a megszakításokkal kapcsolatban?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.it-IT.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.it-IT.xlf
@@ -994,6 +994,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Hai bisogno di aiuto con le interruzioni?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.ja-JP.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.ja-JP.xlf
@@ -980,6 +980,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">中断についてサポートが必要ですか?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.ko-KR.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.ko-KR.xlf
@@ -984,6 +984,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">방해와 관련하여 도움이 필요하십니까?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.nl-BE.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.nl-BE.xlf
@@ -989,6 +989,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Hulp nodig bij onderbrekingen?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
@@ -985,6 +985,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Potrzebujesz pomocy z przerwami?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pt-PT.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pt-PT.xlf
@@ -984,6 +984,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Precisa de ajuda com interrupções?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.sv-SE.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.sv-SE.xlf
@@ -986,6 +986,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Behöver du hjälp med avbrott?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.tr.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.tr.xlf
@@ -994,6 +994,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Kesintilerle ilgili yardıma mı ihtiyacınız var?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.uk-UA.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.uk-UA.xlf
@@ -985,6 +985,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">Потрібна допомога при перебоях?</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="new">Output device</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="new">Choose where to play sound</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.zh-CN.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.zh-CN.xlf
@@ -983,6 +983,14 @@
           <source>Need help with interruptions?</source>
           <target state="translated">需要中断方面的帮助？</target>
         </trans-unit>
+        <trans-unit id="SettingsOutputDevice" translate="yes" xml:space="preserve">
+          <source>Output device</source>
+          <target state="translated">输出设备</target>
+        </trans-unit>
+        <trans-unit id="SettingsOutputDeviceDescription" translate="yes" xml:space="preserve">
+          <source>Choose where to play sound</source>
+          <target state="translated">选择用来播放音效的设备</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/AmbientSounds.Uwp/Services/AudioDeviceService.cs
+++ b/src/AmbientSounds.Uwp/Services/AudioDeviceService.cs
@@ -8,52 +8,56 @@ using JeniusApps.Common.Tools;
 using Windows.Devices.Enumeration;
 using Windows.Media.Devices;
 
-namespace AmbientSounds.Services
+#nullable enable
+
+namespace AmbientSounds.Services;
+
+/// <summary>
+/// Class for getting audio device information.
+/// </summary>
+public class AudioDeviceService : IAudioDeviceService
 {
-    public class AudioDeviceService : IAudioDeviceService
+    private readonly ILocalizer _localizer;
+
+    public AudioDeviceService(ILocalizer localizer)
     {
-        private readonly ILocalizer _localizer;
+        _localizer = localizer;
+    }
 
-        public AudioDeviceService(ILocalizer localizer)
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<AudioDeviceDescriptor>> GetAudioDeviceDescriptorsAsync()
+    {
+        string audioSelector = MediaDevice.GetAudioRenderSelector();
+        var outputDevices = await DeviceInformation.FindAllAsync(audioSelector);
+
+        var list = outputDevices.Select(x => new AudioDeviceDescriptor
         {
-            _localizer = localizer;
-        }
+            DeviceId = x.Id,
+            DeviceName = x.Name
+        }).ToList();
 
-        /// <inheritdoc/>
-        public async Task<IReadOnlyList<AudioDeviceDescriptor>> GetAudioDeviceDescriptorsAsync()
+        if (list is null)
         {
-            string audioSelector = MediaDevice.GetAudioRenderSelector();
-            var outputDevices = await DeviceInformation.FindAllAsync(audioSelector);
-
-            var list = outputDevices.Select(x => new AudioDeviceDescriptor
+            list = new List<AudioDeviceDescriptor>()
             {
-                DeviceId = x.Id,
-                DeviceName = x.Name
-            }).ToList();
-
-            if (list is null)
-            {
-                list = new List<AudioDeviceDescriptor>()
-                {
-                    GetDefaultAudioDeviceDescriptor()
-                };
-            }
-            else
-            {
-                list.Insert(0, GetDefaultAudioDeviceDescriptor());
-            }
-
-            return list;
-        }
-
-        /// <inheritdoc/>
-        public AudioDeviceDescriptor GetDefaultAudioDeviceDescriptor()
-        {
-            return new AudioDeviceDescriptor
-            {
-                DeviceId = string.Empty,
-                DeviceName = _localizer.GetString("Default")
+                GetDefaultAudioDeviceDescriptor()
             };
         }
+        else
+        {
+            list.Insert(0, GetDefaultAudioDeviceDescriptor());
+        }
+
+        return list;
+    }
+
+    /// <inheritdoc/>
+    public AudioDeviceDescriptor GetDefaultAudioDeviceDescriptor()
+    {
+        return new AudioDeviceDescriptor
+        {
+            DeviceId = string.Empty,
+            DeviceName = _localizer.GetString("Default")
+        };
     }
 }

--- a/src/AmbientSounds.Uwp/Services/AudioDeviceService.cs
+++ b/src/AmbientSounds.Uwp/Services/AudioDeviceService.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AmbientSounds.Models;
+using JeniusApps.Common.Tools;
+using Windows.Devices.Enumeration;
+using Windows.Media.Devices;
+
+namespace AmbientSounds.Services
+{
+    public class AudioDeviceService : IAudioDeviceService
+    {
+        private readonly ILocalizer _localizer;
+
+        public AudioDeviceService(ILocalizer localizer)
+        {
+            _localizer = localizer;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IReadOnlyList<AudioDeviceDescriptor>> GetAudioDeviceDescriptorsAsync()
+        {
+            string audioSelector = MediaDevice.GetAudioRenderSelector();
+            var outputDevices = await DeviceInformation.FindAllAsync(audioSelector);
+
+            var list = outputDevices.Select(x => new AudioDeviceDescriptor
+            {
+                DeviceId = x.Id,
+                DeviceName = x.Name
+            }).ToList();
+
+            if (list is null)
+            {
+                list = new List<AudioDeviceDescriptor>()
+                {
+                    GetDefaultAudioDeviceDescriptor()
+                };
+            }
+            else
+            {
+                list.Insert(0, GetDefaultAudioDeviceDescriptor());
+            }
+
+            return list;
+        }
+
+        /// <inheritdoc/>
+        public AudioDeviceDescriptor GetDefaultAudioDeviceDescriptor()
+        {
+            return new AudioDeviceDescriptor
+            {
+                DeviceId = string.Empty,
+                DeviceName = _localizer.GetString("Default")
+            };
+        }
+    }
+}

--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.generated.cs
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.generated.cs
@@ -1,4 +1,5 @@
 // File generated automatically by ReswPlus. https://github.com/DotNetPlus/ReswPlus
+// The NuGet package ReswPlusLib is necessary to support Pluralization.
 using System;
 using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml.Markup;
@@ -2302,6 +2303,32 @@ namespace AmbientSounds.Strings{
             }
         }
         #endregion
+
+        #region SettingsOutputDevice
+        /// <summary>
+        ///   Looks up a localized string similar to: Output device
+        /// </summary>
+        public static string SettingsOutputDevice
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsOutputDevice");
+            }
+        }
+        #endregion
+
+        #region SettingsOutputDeviceDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: Choose where to play sound
+        /// </summary>
+        public static string SettingsOutputDeviceDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsOutputDeviceDescription");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2489,6 +2516,8 @@ namespace AmbientSounds.Strings{
             InterruptionInsightsMessage,
             RecentInterruptionsText,
             InterruptionInsightsButtonText,
+            SettingsOutputDevice,
+            SettingsOutputDeviceDescription,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/en-US/Resources.resw
@@ -850,4 +850,10 @@
   <data name="InterruptionInsightsButtonText" xml:space="preserve">
     <value>Need help with interruptions?</value>
   </data>
+  <data name="SettingsOutputDevice" xml:space="preserve">
+    <value>Output device</value>
+  </data>
+  <data name="SettingsOutputDeviceDescription" xml:space="preserve">
+    <value>Choose where to play sound</value>
+  </data>
 </root>

--- a/src/AmbientSounds.Uwp/Strings/zh-CN/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/zh-CN/Resources.resw
@@ -745,4 +745,10 @@
   <data name="InterruptionInsightsButtonText" xml:space="preserve">
     <value>需要中断方面的帮助？</value>
   </data>
+  <data name="SettingsOutputDevice" xml:space="preserve">
+    <value>输出设备</value>
+  </data>
+  <data name="SettingsOutputDeviceDescription" xml:space="preserve">
+    <value>选择用来播放音效的设备</value>
+  </data>
 </root>

--- a/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayer.cs
+++ b/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayer.cs
@@ -22,9 +22,9 @@ public class WindowsMediaPlayer : IMediaPlayer
     private readonly MediaPlayer _player;
     private readonly IUserSettings _userSettings;
     private string _lastUsedOutputDeviceId = string.Empty;
-    private TaskCompletionSource<bool> _mediaOpenCompletionSource = null;
+    private TaskCompletionSource<bool>? _mediaOpenCompletionSource = null;
 
-    public WindowsMediaPlayer(bool disableSystemControls = false)
+    public WindowsMediaPlayer(IUserSettings userSettings, bool disableSystemControls = false)
     {
         var player = new MediaPlayer();
         if (disableSystemControls)
@@ -35,7 +35,7 @@ public class WindowsMediaPlayer : IMediaPlayer
         _player.MediaOpened += _player_MediaOpened;
         _player.MediaFailed += _player_MediaFailed;
 
-        _userSettings = App.Services.GetRequiredService<IUserSettings>();
+        _userSettings = userSettings;
         _userSettings.SettingSet += _userSettings_SettingSet;
     }
 
@@ -124,6 +124,9 @@ public class WindowsMediaPlayer : IMediaPlayer
             return;
         }
 
+        // Fallback to use the currently selected default audio device if we can't find a valid device
+        // Id from the settings. And also subscribed the event to listen to the change of the default
+        // audio device.
         if (string.IsNullOrEmpty(outputDeviceId))
         {
             outputDeviceId = MediaDevice.GetDefaultAudioRenderId(AudioDeviceRole.Default);

--- a/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayer.cs
+++ b/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayer.cs
@@ -1,6 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using AmbientSounds.Constants;
+using AmbientSounds.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Windows.Devices.Enumeration;
 using Windows.Media.Core;
+using Windows.Media.Devices;
 using Windows.Media.Playback;
 using Windows.Storage;
 
@@ -14,6 +20,9 @@ namespace AmbientSounds.Tools.Uwp;
 public class WindowsMediaPlayer : IMediaPlayer
 {
     private readonly MediaPlayer _player;
+    private readonly IUserSettings _userSettings;
+    private string _lastUsedOutputDeviceId = string.Empty;
+    private TaskCompletionSource<bool> _mediaOpenCompletionSource = null;
 
     public WindowsMediaPlayer(bool disableSystemControls = false)
     {
@@ -23,6 +32,11 @@ public class WindowsMediaPlayer : IMediaPlayer
             player.CommandManager.IsEnabled = false;
         }
         _player = player;
+        _player.MediaOpened += _player_MediaOpened;
+        _player.MediaFailed += _player_MediaFailed;
+
+        _userSettings = App.Services.GetRequiredService<IUserSettings>();
+        _userSettings.SettingSet += _userSettings_SettingSet;
     }
 
     /// <inheritdoc/>
@@ -33,13 +47,24 @@ public class WindowsMediaPlayer : IMediaPlayer
     }
 
     /// <inheritdoc/>
-    public void Play() => _player.Play();
+    public void Play()
+    {
+        SetOutputDevice();
+        _player.Play();
+    }
 
     /// <inheritdoc/>
     public void Pause() => _player.Pause();
 
     /// <inheritdoc/>
-    public void Dispose() => _player.Dispose();
+    public void Dispose()
+    {
+        _userSettings.SettingSet -= _userSettings_SettingSet;
+        MediaDevice.DefaultAudioRenderDeviceChanged -= MediaDevice_DefaultAudioRenderDeviceChanged;
+        _player.MediaOpened -= _player_MediaOpened;
+        _player.MediaFailed -= _player_MediaFailed;
+        _player.Dispose();
+    }
 
     /// <inheritdoc/>
     public bool SetUriSource(Uri uriSource, bool enableGaplessLoop = false)
@@ -88,5 +113,76 @@ public class WindowsMediaPlayer : IMediaPlayer
         var playbackList = new MediaPlaybackList() { AutoRepeatEnabled = true };
         playbackList.Items.Add(item);
         return playbackList;
+    }
+
+    private async void SetOutputDevice()
+    {
+        var outputDeviceId = _userSettings.Get<string>(UserSettingsConstants.OutputAudioDeviceId);
+
+        if (outputDeviceId == _lastUsedOutputDeviceId)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(outputDeviceId))
+        {
+            outputDeviceId = MediaDevice.GetDefaultAudioRenderId(AudioDeviceRole.Default);
+            MediaDevice.DefaultAudioRenderDeviceChanged -= MediaDevice_DefaultAudioRenderDeviceChanged;
+            MediaDevice.DefaultAudioRenderDeviceChanged += MediaDevice_DefaultAudioRenderDeviceChanged;
+        }
+        else
+        {
+            MediaDevice.DefaultAudioRenderDeviceChanged -= MediaDevice_DefaultAudioRenderDeviceChanged;
+        }
+
+        var deviceInformation = await DeviceInformation.CreateFromIdAsync(outputDeviceId);
+
+        // Safely change the output device of the player.
+        // It's not allowed to change the audio device while the player is opening a media file.
+        // We also don't want any exception raised here crashes the app.
+        try
+        {
+            if (_player.PlaybackSession.PlaybackState == Windows.Media.Playback.MediaPlaybackState.Opening)
+            {
+                _mediaOpenCompletionSource = new TaskCompletionSource<bool>();
+                await _mediaOpenCompletionSource.Task;
+                _player.AudioDevice = deviceInformation;
+            }
+            else
+            {
+                _player.AudioDevice = deviceInformation;
+            }
+        }
+        catch (Exception e)
+        {
+            _mediaOpenCompletionSource?.SetException(e);
+        }
+
+        _lastUsedOutputDeviceId = outputDeviceId;
+    }
+
+    private void _player_MediaOpened(MediaPlayer sender, object args)
+    {
+        _mediaOpenCompletionSource?.TrySetResult(true);
+    }
+
+    private void _player_MediaFailed(MediaPlayer sender, MediaPlayerFailedEventArgs args)
+    {
+        _mediaOpenCompletionSource?.TrySetResult(false);
+    }
+
+    private void _userSettings_SettingSet(object sender, string e)
+    {
+        // If the selected output device is changed in settings, updates the player's property to use the new device.
+        if (e == UserSettingsConstants.OutputAudioDeviceId)
+        {
+            SetOutputDevice();
+        }
+    }
+
+    private void MediaDevice_DefaultAudioRenderDeviceChanged(object sender, DefaultAudioRenderDeviceChangedEventArgs args)
+    {
+        // Gets and uses the new output device when the default audio device is changed.
+        SetOutputDevice();
     }
 }

--- a/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayerFactory.cs
+++ b/src/AmbientSounds.Uwp/Tools/WindowsMediaPlayerFactory.cs
@@ -1,10 +1,19 @@
-﻿namespace AmbientSounds.Tools.Uwp;
+﻿using AmbientSounds.Services;
+
+namespace AmbientSounds.Tools.Uwp;
 
 public class WindowsMediaPlayerFactory : IMediaPlayerFactory
 {
+    private readonly IUserSettings _userSettings;
+
+    public WindowsMediaPlayerFactory(IUserSettings userSettings)
+    {
+        _userSettings = userSettings;
+    }
+
     /// <inheritdoc/>
     public IMediaPlayer CreatePlayer(bool disableDefaultSystemControls = false)
     {
-        return new WindowsMediaPlayer(disableDefaultSystemControls);
+        return new WindowsMediaPlayer(_userSettings, disableDefaultSystemControls);
     }
 }

--- a/src/AmbientSounds/Constants/UserSettingsConstants.cs
+++ b/src/AmbientSounds/Constants/UserSettingsConstants.cs
@@ -122,6 +122,11 @@ namespace AmbientSounds.Constants
         public const string HasLoadedPackagedSoundsKey = "HasLoadedPackagedSounds";
 
         /// <summary>
+        /// Used to remember the ID of the input audio device.
+        /// </summary>
+        public const string OutputAudioDeviceId = "OutputAudioDeviceId";
+
+        /// <summary>
         ///  Settings defaults.
         /// </summary>
         public static IReadOnlyDictionary<string, object> Defaults { get; } = new Dictionary<string, object>()
@@ -147,6 +152,7 @@ namespace AmbientSounds.Constants
             { DevicePresenceIdKey, string.Empty },
             { CompactOnFocusKey, true },
             { HasLoadedPackagedSoundsKey, false },
+            { OutputAudioDeviceId, string.Empty }, 
         };
     }
 }

--- a/src/AmbientSounds/Models/AudioDeviceDescriptor.cs
+++ b/src/AmbientSounds/Models/AudioDeviceDescriptor.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AmbientSounds.Models;
+
+public class AudioDeviceDescriptor
+{
+    /// <summary>
+    /// A string representing the identity of the device.
+    /// See also docs of <seealso href="https://learn.microsoft.com/en-us/uwp/api/windows.devices.enumeration.deviceinformation.id">DeviceInformation.Id</seealso>
+    /// </summary>
+    public string? DeviceId { get; init; }
+
+    /// <summary>
+    /// The name of the device. This name is in the best available language for the app.
+    /// </summary>
+    public string DeviceName { get; init; } = string.Empty;
+
+}

--- a/src/AmbientSounds/Services/IAudioDeviceService.cs
+++ b/src/AmbientSounds/Services/IAudioDeviceService.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AmbientSounds.Models;
+
+namespace AmbientSounds.Services;
+
+/// <summary>
+/// Interface for getting audio device information.
+/// </summary>
+public interface IAudioDeviceService
+{
+    /// <summary>
+    /// Gets all the currently available audio devices that can be used as the endpoint for sound playback.
+    /// </summary>
+    /// <returns></returns>
+    Task<IReadOnlyList<AudioDeviceDescriptor>> GetAudioDeviceDescriptorsAsync();
+
+    /// <summary>
+    /// Gets the descriptor of the default audio device.
+    /// </summary>
+    /// <returns></returns>
+    AudioDeviceDescriptor GetDefaultAudioDeviceDescriptor();
+}

--- a/src/AmbientSounds/Services/IAudioDeviceService.cs
+++ b/src/AmbientSounds/Services/IAudioDeviceService.cs
@@ -14,12 +14,12 @@ public interface IAudioDeviceService
     /// <summary>
     /// Gets all the currently available audio devices that can be used as the endpoint for sound playback.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>A list of available audio devices.</returns>
     Task<IReadOnlyList<AudioDeviceDescriptor>> GetAudioDeviceDescriptorsAsync();
 
     /// <summary>
     /// Gets the descriptor of the default audio device.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The default audio device which is available for sound playback.</returns>
     AudioDeviceDescriptor GetDefaultAudioDeviceDescriptor();
 }

--- a/src/AmbientSounds/ViewModels/SettingsViewModel.cs
+++ b/src/AmbientSounds/ViewModels/SettingsViewModel.cs
@@ -128,9 +128,6 @@ namespace AmbientSounds.ViewModels
                 // every time the settings page is opened, and we use a two way
                 // binding for the ComboBox, we don't want to set CurrentOutputDeviceId
                 // before the list is updated.
-                // Here we also check if the target Id is in the list of available devices.
-                // If not, set the current device to empty which means Ambie will
-                // chooses the default device next time.
                 if (OutputDevices.Count > 0)
                 {
                     CurrentOutputDeviceId = targetId;


### PR DESCRIPTION
This PR adds support for users to choose output device for sound playback.

A new settings card is added to the settings page with a ComboBox listing all currently available devices for playing the sounds.

Users may expect to specifically use a physical or virtual device for Ambie to play sounds. For example, using a sound bar to play Ambie sounds to make people feel cozy in the room while listening to a podcast with a headset. There're also many widely used audio mixer applications like VoiceMeeter, SteelSeries SONAR etc.  SteelSeries's SONAR software adds three virtual audio devices for gaming, media, and chat. Users can easily adjust the balance between those channels or apply different EQ profiles.

### How to test:

1. Launch Ambie and choose a different device as the output device like your monitor, a soundbar, a headset or a virtual device from a mixer software. All the currently playing sounds should be redirected to use the new endpoint for playback in real time.
2. While keeping using the default device, open the system sound settings, change the default output device of the system and check if Ambie immediately uses the new default device to play the sounds.

### Localization:
The strings for Simplified Chinese have been manually translated in this PR. @dpaulino You may need to trigger the machine translation generation again to ensure the strings are also translated in other languages.

