### PR TITLE
Hide cursor on inactivity in screensaver

### DIFF
--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -98,6 +98,9 @@ public sealed partial class ScreensaverPage : Page
         coreWindow.SizeChanged -= CoreWindow_SizeChanged;
         var navigator = SystemNavigationManager.GetForCurrentView();
         navigator.BackRequested -= OnBackRequested;
+        
+        InactiveTimer?.Stop();
+        CoreWindow.GetForCurrentThread().PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
 
         SettingsFlyout?.Items?.Clear();
         _displayRequest.RequestRelease();

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -261,11 +261,10 @@ public sealed partial class ScreensaverPage : Page
     {
         if (!IsButtonsHidden)
         {
-
             GoBackButton.Visibility = Visibility.Collapsed;
             ActionButtons.Visibility = Visibility.Collapsed;
+            CoreWindow.GetForCurrentThread().PointerCursor = null;
             IsButtonsHidden = true;
-
         }
 
         InactiveTimer?.Stop();
@@ -277,6 +276,7 @@ public sealed partial class ScreensaverPage : Page
         {
             GoBackButton.Visibility = Visibility.Visible;
             ActionButtons.Visibility = Visibility.Visible;
+            CoreWindow.GetForCurrentThread().PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
             IsButtonsHidden = false;
         }
 


### PR DESCRIPTION
To get an unobstructed view of those gorgeous shaders, this PR hides the cursor when the on-screen buttons automatically hide. This is an experience that users will relate to, as it works like video players do. The cursor is only hidden if it is on top of the Ambie window.