### PR TITLE
Update ComputeSharp to 2.0.1-preview2 (from public feed)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,5 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="toolkit-labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
-    <add key="computesharp-preview" value="https://pkgs.computesharp.dev/index.json" />
   </packageSources>
 </configuration>

--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -676,7 +676,7 @@
       <Version>0.0.11</Version>
     </PackageReference>
     <PackageReference Include="ComputeSharp.D2D1.Uwp">
-      <Version>2.1.0-alpha.4395539716</Version>
+      <Version>2.1.0-preview1</Version>
     </PackageReference>
     <PackageReference Include="JeniusApps.Common.Uwp">
       <Version>0.0.3-preview</Version>

--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -676,7 +676,7 @@
       <Version>0.0.11</Version>
     </PackageReference>
     <PackageReference Include="ComputeSharp.D2D1.Uwp">
-      <Version>2.1.0-preview1</Version>
+      <Version>2.1.0-preview2</Version>
     </PackageReference>
     <PackageReference Include="JeniusApps.Common.Uwp">
       <Version>0.0.3-preview</Version>

--- a/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
+++ b/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
@@ -96,6 +96,17 @@ public abstract class AnimatedWallpaperEffect : CanvasEffect
             _effect!.ConstantBuffer = _factory(ScreenWidth, ScreenHeight, ElapsedTime);
         }
 
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                _effect?.Dispose();
+            }
+        }
+
         /// <summary>
         /// A factory of a given shader instance.
         /// </summary>

--- a/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
+++ b/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.Uwp;
-using Microsoft.Graphics.Canvas;
 
 #nullable enable
 
@@ -63,14 +61,14 @@ public abstract class AnimatedWallpaperEffect : CanvasEffect
         where T : unmanaged, ID2D1PixelShader
     {
         /// <summary>
+        /// The <see cref="PixelShaderEffect{T}"/> node instance in use.
+        /// </summary>
+        private static readonly EffectNode<PixelShaderEffect<T>> EffectNode = new();
+
+        /// <summary>
         /// The <typeparamref name="T"/> factory to use.
         /// </summary>
         private readonly Factory _factory;
-
-        /// <summary>
-        /// The <see cref="PixelShaderEffect{T}"/> instance in use.
-        /// </summary>
-        private PixelShaderEffect<T>? _effect;
 
         /// <summary>
         /// Creates a new <see cref="For{T}"/> instance with the specified parameters.
@@ -82,29 +80,15 @@ public abstract class AnimatedWallpaperEffect : CanvasEffect
         }
 
         /// <inheritdoc/>
-        [MemberNotNull(nameof(_effect))]
-        protected override ICanvasImage BuildEffectGraph()
+        protected override void BuildEffectGraph(EffectGraph effectGraph)
         {
-            _effect = new PixelShaderEffect<T>();
-
-            return _effect;
+            effectGraph.RegisterOutputNode(EffectNode, new PixelShaderEffect<T>());
         }
 
         /// <inheritdoc/>
-        protected override void ConfigureEffectGraph()
+        protected override void ConfigureEffectGraph(EffectGraph effectGraph)
         {
-            _effect!.ConstantBuffer = _factory(ScreenWidth, ScreenHeight, ElapsedTime);
-        }
-
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-
-            if (disposing)
-            {
-                _effect?.Dispose();
-            }
+            effectGraph.GetNode(EffectNode).ConstantBuffer = _factory(ScreenWidth, ScreenHeight, ElapsedTime);
         }
 
         /// <summary>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -111,6 +111,9 @@ public sealed partial class ScreensaverPage : Page
         WallpaperCanvasControl.Draw -= CanvasAnimatedControl_Draw;
         WallpaperCanvasControl.RemoveFromVisualTree();
         WallpaperCanvasControl = null;
+
+        // Also dispose the effect to remove pressure from the GC
+        _animatedWallpaperEffect?.Dispose();
     }
 
     private void OnViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -290,6 +293,9 @@ public sealed partial class ScreensaverPage : Page
     private void SetupAnimatedShaderProperties()
     {
         string? animatedBackgroundName = ViewModel.AnimatedBackgroundName;
+
+        // Dispose the existing effect, if there is one
+        _animatedWallpaperEffect?.Dispose();
 
         // We need explicit references to all type to help the .NET Native linker resolve all type dependencies
         _animatedWallpaperEffect = animatedBackgroundName switch

--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="CommunityToolkit.Common" Version="8.1.0" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-    <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-preview1" />
+    <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-preview2" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.ar" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.bg" Version="2.14.1" />

--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="CommunityToolkit.Common" Version="8.1.0" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-    <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-alpha.4395539716" />
+    <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-preview1" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.ar" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.bg" Version="2.14.1" />


### PR DESCRIPTION
This PR updates ComputeSharp to the public preview and removes the private ADO feed 😄
Small follow up to #339. Also properly disposes shaders when no longer using them.