### PR TITLE
Update .NET Community Toolkit to 8.2.0

### DIFF
--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="CommunityToolkit.Common" Version="8.1.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.1.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-alpha.4395539716" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.ar" Version="2.14.1" />
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.17" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
-    <PackageReference Include="PolySharp" Version="1.11.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/AmbientSounds/ViewModels/CompactPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/CompactPageViewModel.cs
@@ -78,6 +78,6 @@ public sealed partial class CompactPageViewModel : ObservableObject
     private async Task CloseCompactAsync()
     {
         _telemetry.TrackEvent(TelemetryConstants.MiniBack);
-        await _navigator.CloseCompactOverlayAsync(_currentView);
+        await _navigator.CloseCompactOverlayAsync(CurrentView);
     }
 }

--- a/src/AmbientSounds/ViewModels/FocusPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/FocusPageViewModel.cs
@@ -49,8 +49,8 @@ public partial class FocusPageViewModel : ObservableObject
     public async Task InitializeAsync()
     {
         _focusService.FocusStateChanged += OnFocusStateChanged;
-        _notes = await _focusNotesService.GetStoredNotesAsync();
-        OnPropertyChanged(nameof(Notes));
+
+        Notes = await _focusNotesService.GetStoredNotesAsync();
     }
 
     public void Uninitialize()


### PR DESCRIPTION
This PR updates the .NET Community Toolkit to the latest stable release and fixes two warnings.