### PR TITLE
Fix crash in shader exception handler

### DIFF
--- a/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
+++ b/src/AmbientSounds.Uwp/Effects/AnimatedWallpaperEffect.cs
@@ -54,6 +54,11 @@ public abstract class AnimatedWallpaperEffect : CanvasEffect
     }
 
     /// <summary>
+    /// Gets the name of the effect currently in use.
+    /// </summary>
+    public abstract string EffectName { get; }
+
+    /// <summary>
     /// An effect for an animated wallpaper.
     /// </summary>
     /// <typeparam name="T">The type of wallpepr to render.</typeparam>
@@ -78,6 +83,9 @@ public abstract class AnimatedWallpaperEffect : CanvasEffect
         {
             _factory = factory;
         }
+
+        /// <inheritdoc/>
+        public override string EffectName => typeof(T).Name;
 
         /// <inheritdoc/>
         protected override void BuildEffectGraph(EffectGraph effectGraph)


### PR DESCRIPTION
This PR fixes the following crash:

![image](https://github.com/jenius-apps/ambie/assets/10199417/8c41c5cc-574a-4e15-b62e-49e56dbf12cc)

This was due to the shader draw handler not dispatching back to the UI thread when logging exceptions.