### PR TITLE
Fix contrast issue with light theme in screensaver page.

### DIFF
--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
@@ -38,7 +38,6 @@
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
             Click="GoBack"
-            RequestedTheme="Dark"
             Style="{StaticResource IconButton}">
             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xE921;" />
         </Button>
@@ -49,7 +48,6 @@
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
             Orientation="Horizontal"
-            RequestedTheme="Dark"
             Name="ActionButtons">
             <Button
                 AutomationProperties.Name="{x:Bind strings:Resources.ToggleFullscreen}"


### PR DESCRIPTION
This pull request is a fix for issue #351.

The RequestedTheme property was hardcoded to Dark, which caused issues when using light mode.