### PR TITLE
Remove hardcoded SystemAccentColor resources.

### DIFF
--- a/src/AmbientSounds.Uwp/App.xaml
+++ b/src/AmbientSounds.Uwp/App.xaml
@@ -13,8 +13,8 @@
             </ResourceDictionary.MergedDictionaries>
 
             <ResourceDictionary.ThemeDictionaries>
-				<ResourceDictionary x:Key="Light">
-					<LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
+                <ResourceDictionary x:Key="Light">
+                    <LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
                         <GradientStop Offset="0" Color="#539AFF" />
                         <GradientStop Offset="1" Color="#53BEFF" />
                     </LinearGradientBrush>
@@ -32,8 +32,8 @@
                     <SolidColorBrush x:Key="CardStrokeBrush" Color="#d1d1d1" />
                     <SolidColorBrush x:Key="ContentBackgroundBrush" Color="White" />
                 </ResourceDictionary>
-				<ResourceDictionary x:Key="Dark">
-					<LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
+                <ResourceDictionary x:Key="Dark">
+                    <LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
                         <GradientStop Offset="0" Color="#427BCC" />
                         <GradientStop Offset="1" Color="#539AFF" />
                     </LinearGradientBrush>

--- a/src/AmbientSounds.Uwp/App.xaml
+++ b/src/AmbientSounds.Uwp/App.xaml
@@ -13,16 +13,8 @@
             </ResourceDictionary.MergedDictionaries>
 
             <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <Color x:Key="SystemAccentColor">#e37700</Color>
-                    <Color x:Key="SystemAccentColorLight1">#FFE8881E</Color>
-                    <Color x:Key="SystemAccentColorLight2">#FFED993C</Color>
-                    <Color x:Key="SystemAccentColorLight3">#FFF1AA5A</Color>
-                    <Color x:Key="SystemAccentColorDark1">#FFCE6500</Color>
-                    <Color x:Key="SystemAccentColorDark2">#FFB85300</Color>
-                    <Color x:Key="SystemAccentColorDark3">#FFA34100</Color>
-
-                    <LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
+				<ResourceDictionary x:Key="Light">
+					<LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
                         <GradientStop Offset="0" Color="#539AFF" />
                         <GradientStop Offset="1" Color="#53BEFF" />
                     </LinearGradientBrush>
@@ -40,15 +32,8 @@
                     <SolidColorBrush x:Key="CardStrokeBrush" Color="#d1d1d1" />
                     <SolidColorBrush x:Key="ContentBackgroundBrush" Color="White" />
                 </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <Color x:Key="SystemAccentColor">#FFB900</Color>
-                    <Color x:Key="SystemAccentColorLight1">#FFFFC21E</Color>
-                    <Color x:Key="SystemAccentColorLight2">#FFFFCB3C</Color>
-                    <Color x:Key="SystemAccentColorLight3">#FFFFD359</Color>
-                    <Color x:Key="SystemAccentColorDark1">#FFE6A400</Color>
-                    <Color x:Key="SystemAccentColorDark2">#FFCD8F00</Color>
-                    <Color x:Key="SystemAccentColorDark3">#FFB47900</Color>
-                    <LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
+				<ResourceDictionary x:Key="Dark">
+					<LinearGradientBrush x:Key="BlueGradientBrush" StartPoint="0,0.5" EndPoint="1,0.5">
                         <GradientStop Offset="0" Color="#427BCC" />
                         <GradientStop Offset="1" Color="#539AFF" />
                     </LinearGradientBrush>


### PR DESCRIPTION
This allows Ambie to be more consistent with the user's system by replacing the Ambie yellow with the system's accent color.

Closes issue #367.

Before:
![image](https://github.com/jenius-apps/ambie/assets/51166756/9c5d1a13-48bb-4b94-a49c-414ace4a3611)
After:
![image](https://github.com/jenius-apps/ambie/assets/51166756/32093f26-e2d4-4694-8afb-3e1aa3251cb4)
