### PR TITLE
Fix ObjectDisposedException-s when toggling shaders

### DIFF
--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml
@@ -15,9 +15,9 @@
 
     <Grid
         x:Name="RootPage"
+        PointerMoved="RootPage_OnPointerMoved"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        BackgroundTransition="{StaticResource Transition}"
-        PointerMoved="RootPage_OnPointerMoved">
+        BackgroundTransition="{StaticResource Transition}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
                 <VisualState>
@@ -43,12 +43,12 @@
         </Button>
 
         <StackPanel
-            Name="ActionButtons"
             Margin="0,40,40,0"
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
-            Orientation="Horizontal">
+            Orientation="Horizontal"
+            Name="ActionButtons">
             <Button
                 AutomationProperties.Name="{x:Bind strings:Resources.ToggleFullscreen}"
                 Click="OnToggleFullscreen"
@@ -85,15 +85,15 @@
             AutoPlay="True"
             Visibility="{x:Bind ViewModel.VideoPlayerVisible, Mode=OneWay}" />
 
-        <!--<win2d:CanvasAnimatedControl
+        <win2d:CanvasAnimatedControl
             x:Name="WallpaperCanvasControl"
             Draw="CanvasAnimatedControl_Draw"
-            Visibility="{x:Bind ViewModel.AnimatedBackgroundVisible, Mode=OneWay}" />-->
+            Visibility="{x:Bind ViewModel.AnimatedBackgroundVisible, Mode=OneWay}" />
 
         <controls:Screensaver x:Name="ScreensaverControl" x:Load="{x:Bind ViewModel.SlideshowVisible, Mode=OneWay}" />
 
         <!--  Rendering error bar  -->
-        <!--<muxc:InfoBar
+        <muxc:InfoBar
             x:Name="RenderingErrorInfoBar"
             x:Uid="RenderingErrorInfo"
             VerticalAlignment="Bottom"
@@ -103,6 +103,6 @@
             <muxc:InfoBar.ActionButton>
                 <HyperlinkButton x:Uid="RenderingErrorLink" NavigateUri="mailto:jenius_apps@outlook.com" />
             </muxc:InfoBar.ActionButton>
-        </muxc:InfoBar>-->
+        </muxc:InfoBar>
     </Grid>
 </Page>

--- a/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
+++ b/src/AmbientSounds.Uwp/Views/ScreensaverPage.xaml.cs
@@ -30,8 +30,8 @@ public sealed partial class ScreensaverPage : Page
 {
     private readonly DisplayRequest _displayRequest;
     private readonly DispatcherQueue _dispatcherQueue;
-    //private AnimatedWallpaperEffect? _animatedWallpaperEffect;
-    //private double _resolutionScale;
+    private AnimatedWallpaperEffect? _animatedWallpaperEffect;
+    private double _resolutionScale;
 
     public ScreensaverPage()
     {
@@ -46,7 +46,7 @@ public sealed partial class ScreensaverPage : Page
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
         // Set the wallpapers to run at 24fps to save resources (the animations are very slow, so not noticeable)
-        //WallpaperCanvasControl.TargetElapsedTime = TimeSpan.FromSeconds(1 / 24.0f);
+        WallpaperCanvasControl.TargetElapsedTime = TimeSpan.FromSeconds(1 / 24.0f);
 
         Unloaded += ScreensaverPage_Unloaded;
     }
@@ -113,12 +113,12 @@ public sealed partial class ScreensaverPage : Page
     {
         // Remove the canvas from the visual tree manually to avoid memory leaks.
         // See: https://microsoft.github.io/Win2D/WinUI2/html/RefCycles.htm.
-        //WallpaperCanvasControl.Draw -= CanvasAnimatedControl_Draw;
-        //WallpaperCanvasControl.RemoveFromVisualTree();
-        //WallpaperCanvasControl = null;
+        WallpaperCanvasControl.Draw -= CanvasAnimatedControl_Draw;
+        WallpaperCanvasControl.RemoveFromVisualTree();
+        WallpaperCanvasControl = null;
 
-        //// Also dispose the effect to remove pressure from the GC
-        //_animatedWallpaperEffect?.Dispose();
+        // Also dispose the effect to remove pressure from the GC
+        _animatedWallpaperEffect?.Dispose();
     }
 
     private void OnViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -128,10 +128,10 @@ public sealed partial class ScreensaverPage : Page
             VideoPlayer.MediaPlayer.IsLoopingEnabled = true;
             VideoPlayer.MediaPlayer.Source = MediaSource.CreateFromUri(ViewModel.VideoSource);
         }
-        //else if (e.PropertyName == nameof(ViewModel.AnimatedBackgroundName))
-        //{
-        //    SetupAnimatedShaderProperties();
-        //}
+        else if (e.PropertyName == nameof(ViewModel.AnimatedBackgroundName))
+        {
+            SetupAnimatedShaderProperties();
+        }
     }
 
     private void OnViewModelLoaded(object sender, EventArgs e)
@@ -166,7 +166,7 @@ public sealed partial class ScreensaverPage : Page
             SettingsFlyout.Items.Add(menuItem);
         }
 
-        //SetupAnimatedShaderProperties();
+        SetupAnimatedShaderProperties();
     }
 
     private void OnMenuItemClicked(object sender, RoutedEventArgs e)
@@ -295,75 +295,75 @@ public sealed partial class ScreensaverPage : Page
     /// <summary>
     /// Configures the shader runner and resolution scale when the control is loaded or the selected shader changes.
     /// </summary>
-    //private void SetupAnimatedShaderProperties()
-    //{
-    //    string? animatedBackgroundName = ViewModel.AnimatedBackgroundName;
+    private void SetupAnimatedShaderProperties()
+    {
+        string? animatedBackgroundName = ViewModel.AnimatedBackgroundName;
 
-    //    // Dispose the existing effect, if there is one
-    //    _animatedWallpaperEffect?.Dispose();
+        // Dispose the existing effect, if there is one
+        _animatedWallpaperEffect?.Dispose();
 
-    //    // We need explicit references to all type to help the .NET Native linker resolve all type dependencies
-    //    _animatedWallpaperEffect = animatedBackgroundName switch
-    //    {
-    //        nameof(ColorfulInfinity) => new AnimatedWallpaperEffect.For<ColorfulInfinity>((width, height, time) => new ColorfulInfinity((float)time.TotalSeconds / 16f, new int2(width, height))),
-    //        nameof(ProteanClouds) => new AnimatedWallpaperEffect.For<ProteanClouds>((width, height, time) => new ProteanClouds((float)time.TotalSeconds / 16f, new int2(width, height))),
-    //        _ => null
-    //    };
+        // We need explicit references to all type to help the .NET Native linker resolve all type dependencies
+        _animatedWallpaperEffect = animatedBackgroundName switch
+        {
+            nameof(ColorfulInfinity) => new AnimatedWallpaperEffect.For<ColorfulInfinity>((width, height, time) => new ColorfulInfinity((float)time.TotalSeconds / 16f, new int2(width, height))),
+            nameof(ProteanClouds) => new AnimatedWallpaperEffect.For<ProteanClouds>((width, height, time) => new ProteanClouds((float)time.TotalSeconds / 16f, new int2(width, height))),
+            _ => null
+        };
 
-    //    // Configure the resolution scale, to save GPU computation. The scale is picked to
-    //    // maintain enough visual quality, so it depends on the visuals of each shader.
-    //    // In general, shaders with more fine grained details need a higher resolution.
-    //    _resolutionScale = animatedBackgroundName switch
-    //    {
-    //        nameof(ColorfulInfinity) => 0.5,
-    //        nameof(ProteanClouds) => 0.4,
-    //        _ => 1.0
-    //    };
-    //}
+        // Configure the resolution scale, to save GPU computation. The scale is picked to
+        // maintain enough visual quality, so it depends on the visuals of each shader.
+        // In general, shaders with more fine grained details need a higher resolution.
+        _resolutionScale = animatedBackgroundName switch
+        {
+            nameof(ColorfulInfinity) => 0.5,
+            nameof(ProteanClouds) => 0.4,
+            _ => 1.0
+        };
+    }
 
-    //private void CanvasAnimatedControl_Draw(ICanvasAnimatedControl sender, CanvasAnimatedDrawEventArgs args)
-    //{
-    //    // We do need an effect to draw (which should be available)
-    //    if (_animatedWallpaperEffect is not { } animatedWallpaperEffect)
-    //    {
-    //        return;
-    //    }
+    private void CanvasAnimatedControl_Draw(ICanvasAnimatedControl sender, CanvasAnimatedDrawEventArgs args)
+    {
+        // We do need an effect to draw (which should be available)
+        if (_animatedWallpaperEffect is not { } animatedWallpaperEffect)
+        {
+            return;
+        }
 
-    //    try
-    //    {
-    //        double resolutionScale = _resolutionScale;
-    //        Size canvasSize = sender.Size;
-    //        Size renderSize = new(canvasSize.Width * resolutionScale, canvasSize.Height * resolutionScale);
+        try
+        {
+            double resolutionScale = _resolutionScale;
+            Size canvasSize = sender.Size;
+            Size renderSize = new(canvasSize.Width * resolutionScale, canvasSize.Height * resolutionScale);
 
-    //        // Set the constant buffer
-    //        animatedWallpaperEffect.ElapsedTime = args.Timing.TotalTime;
-    //        animatedWallpaperEffect.ScreenWidth = sender.ConvertDipsToPixels((float)renderSize.Width, CanvasDpiRounding.Round);
-    //        animatedWallpaperEffect.ScreenHeight = sender.ConvertDipsToPixels((float)renderSize.Height, CanvasDpiRounding.Round);
+            // Set the constant buffer
+            animatedWallpaperEffect.ElapsedTime = args.Timing.TotalTime;
+            animatedWallpaperEffect.ScreenWidth = sender.ConvertDipsToPixels((float)renderSize.Width, CanvasDpiRounding.Round);
+            animatedWallpaperEffect.ScreenHeight = sender.ConvertDipsToPixels((float)renderSize.Height, CanvasDpiRounding.Round);
 
-    //        // Draw the shader with the requested resolution scale
-    //        args.DrawingSession.DrawImage(
-    //            image: animatedWallpaperEffect,
-    //            destinationRectangle: new Rect(0, 0, canvasSize.Width, canvasSize.Height),
-    //            sourceRectangle: new Rect(0, 0, renderSize.Width, renderSize.Height));
-    //    }
-    //    catch (Exception e)
-    //    {
-    //        // Pause rendering
-    //        sender.Paused = true;
+            // Draw the shader with the requested resolution scale
+            args.DrawingSession.DrawImage(
+                image: animatedWallpaperEffect,
+                destinationRectangle: new Rect(0, 0, canvasSize.Width, canvasSize.Height),
+                sourceRectangle: new Rect(0, 0, renderSize.Width, renderSize.Height));
+        }
+        catch (Exception e)
+        {
+            // Pause rendering
+            sender.Paused = true;
 
-    //        // Log the error to telemetry
-    //        App.Services.GetRequiredService<ITelemetry>().TrackError(e, new Dictionary<string, string>()
-    //        {
-    //            { "name", animatedWallpaperEffect.EffectName },
-    //            { "deviceLostReason", $"0x{args.DrawingSession.Device.GetDeviceLostReason():X8}" }
-    //        });
+            // Log the error to telemetry
+            App.Services.GetRequiredService<ITelemetry>().TrackError(e, new Dictionary<string, string>()
+            {
+                { "name", animatedWallpaperEffect.EffectName },
+                { "deviceLostReason", $"0x{args.DrawingSession.Device.GetDeviceLostReason():X8}" }
+            });
 
-    //        // Show the error banner. For this we need to first move back to the UI thread,
-    //        // as the drawing handlers are invoked by a render thread spun up by Win2D.
-    //        _ = _dispatcherQueue.TryEnqueue(() =>
-    //        {
-    //            ((InfoBar)FindName(nameof(RenderingErrorInfoBar))).IsOpen = true;
-    //        });
-    //    }
-    //}
+            // Show the error banner. For this we need to first move back to the UI thread,
+            // as the drawing handlers are invoked by a render thread spun up by Win2D.
+            _ = _dispatcherQueue.TryEnqueue(() =>
+            {
+                ((InfoBar)FindName(nameof(RenderingErrorInfoBar))).IsOpen = true;
+            });
+        }
+    }
 }

--- a/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
+++ b/src/AmbientSounds/ViewModels/ScreensaverPageViewModel.cs
@@ -131,12 +131,12 @@ namespace AmbientSounds.ViewModels
             MenuItems.Add(new FlyoutMenuItem(DarkScreenId, _localizer.GetString("SettingsThemeDarkRadio/Content"), screensaverCommand, DarkScreenId, true));
 
             // Only enable compute shaders on desktop
-            //if (_systemInfoProvider.IsDesktop())
-            //{
-            //    // Animated backgrounds
-            //    MenuItems.Add(new FlyoutMenuItem($"[CS]{nameof(ColorfulInfinity)}", _localizer.GetString("ComputeShader/ColoredSmoke"), screensaverCommand, $"[CS]{nameof(ColorfulInfinity)}", true));
-            //    MenuItems.Add(new FlyoutMenuItem($"[CS]{nameof(ProteanClouds)}", _localizer.GetString("ComputeShader/Clouds"), screensaverCommand, $"[CS]{nameof(ProteanClouds)}", true));
-            //}
+            if (_systemInfoProvider.IsDesktop())
+            {
+                // Animated backgrounds
+                MenuItems.Add(new FlyoutMenuItem($"[CS]{nameof(ColorfulInfinity)}", _localizer.GetString("ComputeShader/ColoredSmoke"), screensaverCommand, $"[CS]{nameof(ColorfulInfinity)}", true));
+                MenuItems.Add(new FlyoutMenuItem($"[CS]{nameof(ProteanClouds)}", _localizer.GetString("ComputeShader/Clouds"), screensaverCommand, $"[CS]{nameof(ProteanClouds)}", true));
+            }
 
             foreach (var v in videos)
             {


### PR DESCRIPTION
### Closes #377

This PR re-enables the animated shaders and fixes a crash that could happen on some devices when toggling between different animated shaders. I've left detailed notes in the comments added in this PR, but TLDR the issue was causing by the property changed handler for the viewmodel changing the shader effect in use and disposing the old one, concurrently with the rendering thread for the Win2D canvas rendering frames. So in some cases, the effect being drawn would be disposed, and fail.