### PR TITLE
Update .NET Community Toolkit to 8.2.1

### DIFF
--- a/src/AmbientSounds/AmbientSounds.csproj
+++ b/src/AmbientSounds/AmbientSounds.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="CommunityToolkit.Common" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="ComputeSharp.D2D1" Version="2.1.0-preview2" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.ar" Version="2.14.1" />


### PR DESCRIPTION
This PR bumps the .NET Community Toolkit to the latest stable release, 8.2.1.
No functional changes, this release only includes some bug fixes and tweaks.
No fixups were needed in Ambie as the new analyzer didn't spot any issues in the existing code.