### PR TITLE
Use CommunityToolkit DI generator to register services

### DIFF
--- a/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
+++ b/src/AmbientSounds.Uwp/AmbientSounds.Uwp.csproj
@@ -681,6 +681,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Labs.Extensions.DependencyInjection">
+      <Version>0.0.1</Version>
+    </PackageReference>
     <PackageReference Include="CommunityToolkit.Labs.Uwp.SettingsControls">
       <Version>0.0.11</Version>
     </PackageReference>

--- a/src/AmbientSounds.Uwp/App.xaml.cs
+++ b/src/AmbientSounds.Uwp/App.xaml.cs
@@ -12,8 +12,10 @@ using JeniusApps.Common.Tools.Uwp;
 using Microsoft.AppCenter;
 using Microsoft.Extensions.DependencyInjection;
 using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Extensions.DependencyInjection;
 using Microsoft.Toolkit.Uwp.Connectivity;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
@@ -31,7 +33,6 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using System.Collections.Generic;
 using JeniusApps.Common.Telemetry;
 using JeniusApps.Common.Telemetry.Uwp;
 using Windows.UI.Core.Preview;
@@ -440,117 +441,25 @@ sealed partial class App : Application
     }
 
     /// <summary>
-    /// Configures a new <see cref="IServiceProvider"/> instance with the required services.
+    /// Builds the <see cref="IServiceProvider"/> instance with the required services.
     /// </summary>
+    /// <param name="appsettings">The <see cref="IAppSettings"/> instance to use, if available.</param>
+    /// <returns>The resulting service provider.</returns>
     private static IServiceProvider ConfigureServices(IAppSettings? appsettings = null)
     {
-        var client = new HttpClient();
+        ServiceCollection collection = new();
 
-        var provider = new ServiceCollection()
-            .AddSingleton(client)
-            // if viewmodel, then always transient unless otherwise stated
-            .AddSingleton<SoundListViewModel>() // shared in main and compact pages
-            .AddTransient<ScreensaverViewModel>()
-            .AddSingleton<ScreensaverPageViewModel>()
-            .AddSingleton<SettingsViewModel>()
-            .AddSingleton<CataloguePageViewModel>()
-            .AddSingleton<FocusTaskModuleViewModel>()
-            .AddSingleton<PremiumControlViewModel>()
-            .AddSingleton<FocusTimerModuleViewModel>()
-            .AddSingleton<ShellPageViewModel>()
-            .AddSingleton<PlayerViewModel>() // shared in main and compact pages
-            .AddSingleton<SleepTimerViewModel>() // shared in main and compact pages
-            .AddSingleton<FocusHistoryModuleViewModel>()
-            .AddSingleton<VideosMenuViewModel>()
-            .AddSingleton<TimeBannerViewModel>()
-            .AddSingleton<UpdatesViewModel>()
-            .AddSingleton<InterruptionPageViewModel>()
-            .AddSingleton<InterruptionInsightsViewModel>()
-            .AddSingleton<DownloadMissingViewModel>()
-            .AddSingleton<ShareViewModel>()
-            .AddSingleton<MeditatePageViewModel>()
-            .AddSingleton<FocusPageViewModel>()
-            .AddSingleton<CompactPageViewModel>()
-            .AddTransient<ActiveTrackListViewModel>()
-            .AddSingleton<AppServiceController>()
-            .AddSingleton<PlaybackModeObserver>()
-            .AddSingleton<ProtocolLaunchController>()
-            // object tree is all transient
-            .AddTransient<IStoreNotificationRegistrar, PartnerCentreNotificationRegistrar>()
-            .AddTransient<IImagePicker, ImagePicker>()
-            .AddSingleton<IClipboard, WindowsClipboard>()
-            .AddSingleton<IAppStoreRatings, MicrosoftStoreRatings>()
-            // Must be transient because this is basically
-            // a timer factory.
-            .AddTransient<ITimerService, TimerService>()
-            // exposes events or object tree has singleton, so singleton.
-            .AddSingleton<IDispatcherQueue, WindowsDispatcherQueue>()
-            .AddSingleton<IFocusNotesService, FocusNotesService>()
-            .AddSingleton<IFocusService, FocusService>()
-            .AddSingleton<IFocusHistoryService, FocusHistoryService>()
-            .AddSingleton<IFocusTaskService, FocusTaskService>()
-            .AddSingleton<IRecentFocusService, RecentFocusService>()
-            .AddSingleton<IDialogService, DialogService>()
-            .AddSingleton<IShareService, ShareService>()
-            .AddSingleton<IPresenceService, PresenceService>()
-            .AddSingleton<IFileDownloader, FileDownloader>()
-            .AddSingleton<ISoundVmFactory, SoundVmFactory>()
-            .AddSingleton<IGuideVmFactory, GuideVmFactory>()
-            .AddSingleton<CatalogueRowVmFactory>()
-            .AddSingleton<ICatalogueService, CatalogueService>()
-            .AddSingleton<IVideoService, VideoService>()
-            .AddSingleton<IFocusTaskCache, FocusTaskCache>()
-            .AddSingleton<IFocusHistoryCache, FocusHistoryCache>()
-            .AddSingleton<IVideoCache, VideoCache>()
-            .AddSingleton<IPageCache, PageCache>()
-            .AddSingleton<IPagesRepository, PagesRepository>()
-            .AddSingleton<IAssetLocalizer, AssetLocalizer>()
-            .AddSingleton<IShareDetailCache, ShareDetailCache>()
-            .AddSingleton<IShareDetailRepository, ShareDetailRepository>()
-            .AddSingleton<IFocusTaskRepository, FocusTaskRepository>()
-            .AddSingleton<IOfflineVideoRepository, OfflineVideoRepository>()
-            .AddSingleton<IOnlineVideoRepository, OnlineVideoRepository>()
-            .AddSingleton<IOfflineSoundRepository, OfflineSoundRepository>()
-            .AddSingleton<IOnlineGuideRepository, OnlineGuideRepository>()
-            .AddSingleton<IOfflineGuideRepository, OfflineGuideRepository>()
-            .AddSingleton<ISoundCache, SoundCache>()
-            .AddSingleton<IGuideCache, GuideCache>()
-            .AddSingleton<ISoundService, SoundService>()
-            .AddSingleton<IGuideService, GuideService>()
-            .AddSingleton<IFocusHistoryRepository, FocusHistoryRepository>()
-            .AddSingleton<IUserSettings, LocalSettings>()
-            .AddSingleton<ISoundMixService, SoundMixService>()
-            .AddSingleton<IRenamer, Renamer>()
-            .AddSingleton<IUpdateService, UpdateService>()
-            .AddSingleton<ILocalizer, ReswLocalizer>()
-            .AddSingleton<IFileWriter, FileWriter>()
-            .AddSingleton<IFilePicker, FilePicker>()
-            .AddSingleton<IFocusToastService, FocusToastService>()
-            .AddSingleton<IToastService, ToastService>()
-            .AddSingleton<Services.INavigator, Services.Uwp.Navigator>()
-            .AddSingleton<ICompactNavigator, CompactNavigator>()
-            .AddSingleton<ICloudFileWriter, CloudFileWriter>()
-            .AddSingleton<PlayerTelemetryTracker>()
-            .AddSingleton<ISoundEffectsService, SoundEffectsService>()
-            .AddSingleton<ICatalogueService, CatalogueService>()
-            .AddSingleton<IPreviewService, PreviewService>()
-            .AddSingleton<IIapService, StoreService>()
-            .AddSingleton<IDownloadManager, WindowsDownloadManager>()
-            .AddSingleton<IScreensaverService, ScreensaverService>()
-            .AddSingleton<ITelemetry, AppCenterTelemetry>(s =>
-            {
-                var apiKey = s.GetRequiredService<IAppSettings>().TelemetryApiKey;
-                return new AppCenterTelemetry(apiKey);
-            })
-            .AddSingleton<IOnlineSoundRepository, OnlineSoundRepository>()
-            .AddSingleton<Services.ISystemInfoProvider, Services.Uwp.SystemInfoProvider>()
-            .AddSingleton<Tools.IAssetsReader, Tools.Uwp.AssetsReader>()
-            .AddSingleton<IMixMediaPlayerService, MixMediaPlayerService>()
-            .AddSingleton<ISystemMediaControls, WindowsSystemMediaControls>()
-            .AddSingleton<IAudioDeviceService, AudioDeviceService>()
-            .AddSingleton<IMediaPlayerFactory, WindowsMediaPlayerFactory>()
-            .AddSingleton(appsettings ?? new AppSettings())
-            .BuildServiceProvider(true);
+        ConfigureServices(collection);
+
+        // Manually register additional services requiring more customization
+        collection.AddSingleton(appsettings ?? new AppSettings());
+        collection.AddSingleton<ITelemetry, AppCenterTelemetry>(s =>
+        {
+            var apiKey = s.GetRequiredService<IAppSettings>().TelemetryApiKey;
+            return new AppCenterTelemetry(apiKey);
+        });
+        
+        IServiceProvider provider = collection.BuildServiceProvider();
 
         // preload telemetry to ensure country code is set.
         provider.GetService<ITelemetry>();
@@ -565,4 +474,100 @@ sealed partial class App : Application
 
         return provider;
     }
+
+    /// <summary>
+    /// Configures services used by the app.
+    /// </summary>
+    /// <param name="services">The target <see cref="IServiceCollection"/> instance to register services with.</param>
+    [Singleton(typeof(HttpClient))]
+    [Singleton(typeof(SoundListViewModel))] // shared in main and compact pages
+    [Transient(typeof(ScreensaverViewModel))]
+    [Singleton(typeof(ScreensaverPageViewModel))]
+    [Singleton(typeof(SettingsViewModel))]
+    [Singleton(typeof(CataloguePageViewModel))]
+    [Singleton(typeof(FocusTaskModuleViewModel))]
+    [Singleton(typeof(PremiumControlViewModel))]
+    [Singleton(typeof(FocusTimerModuleViewModel))]
+    [Singleton(typeof(ShellPageViewModel))]
+    [Singleton(typeof(PlayerViewModel))] // shared in main and compact pages
+    [Singleton(typeof(SleepTimerViewModel))] // shared in main and compact pages
+    [Singleton(typeof(FocusHistoryModuleViewModel))]
+    [Singleton(typeof(VideosMenuViewModel))]
+    [Singleton(typeof(TimeBannerViewModel))]
+    [Singleton(typeof(UpdatesViewModel))]
+    [Singleton(typeof(InterruptionPageViewModel))]
+    [Singleton(typeof(InterruptionInsightsViewModel))]
+    [Singleton(typeof(DownloadMissingViewModel))]
+    [Singleton(typeof(ShareViewModel))]
+    [Singleton(typeof(MeditatePageViewModel))]
+    [Singleton(typeof(FocusPageViewModel))]
+    [Singleton(typeof(CompactPageViewModel))]
+    [Transient(typeof(ActiveTrackListViewModel))]
+    [Singleton(typeof(AppServiceController))]
+    [Singleton(typeof(PlaybackModeObserver))]
+    [Singleton(typeof(ProtocolLaunchController))]
+    [Transient(typeof(PartnerCentreNotificationRegistrar), typeof(IStoreNotificationRegistrar))]
+    [Transient(typeof(ImagePicker), typeof(IImagePicker))]
+    [Singleton(typeof(WindowsClipboard), typeof(IClipboard))]
+    [Singleton(typeof(MicrosoftStoreRatings), typeof(IAppStoreRatings))]
+    [Transient(typeof(TimerService), typeof(ITimerService))] // Must be transient because this is basically a timer factory
+    [Singleton(typeof(WindowsDispatcherQueue), typeof(IDispatcherQueue))]
+    [Singleton(typeof(FocusNotesService), typeof(IFocusNotesService))]
+    [Singleton(typeof(FocusService), typeof(IFocusService))]
+    [Singleton(typeof(FocusHistoryService), typeof(IFocusHistoryService))]
+    [Singleton(typeof(RecentFocusService), typeof(IRecentFocusService))]
+    [Singleton(typeof(DialogService), typeof(IDialogService))]
+    [Singleton(typeof(ShareService), typeof(IShareService))]
+    [Singleton(typeof(PresenceService), typeof(IPresenceService))]
+    [Singleton(typeof(FileDownloader), typeof(IFileDownloader))]
+    [Singleton(typeof(SoundVmFactory), typeof(ISoundVmFactory))]
+    [Singleton(typeof(GuideVmFactory), typeof(IGuideVmFactory))]
+    [Singleton(typeof(CatalogueRowVmFactory))]
+    [Singleton(typeof(CatalogueService), typeof(ICatalogueService))]
+    [Singleton(typeof(VideoService), typeof(IVideoService))]
+    [Singleton(typeof(FocusTaskCache), typeof(IFocusTaskCache))]
+    [Singleton(typeof(FocusHistoryCache), typeof(IFocusHistoryCache))]
+    [Singleton(typeof(VideoCache), typeof(IVideoCache))]
+    [Singleton(typeof(PageCache), typeof(IPageCache))]
+    [Singleton(typeof(PagesRepository), typeof(IPagesRepository))]
+    [Singleton(typeof(AssetLocalizer), typeof(IAssetLocalizer))]
+    [Singleton(typeof(ShareDetailCache), typeof(IShareDetailCache))]
+    [Singleton(typeof(ShareDetailRepository), typeof(IShareDetailRepository))]
+    [Singleton(typeof(FocusTaskRepository), typeof(IFocusTaskRepository))]
+    [Singleton(typeof(OfflineVideoRepository), typeof(IOfflineVideoRepository))]
+    [Singleton(typeof(OnlineVideoRepository), typeof(IOnlineVideoRepository))]
+    [Singleton(typeof(OfflineSoundRepository), typeof(IOfflineSoundRepository))]
+    [Singleton(typeof(OnlineSoundRepository), typeof(IOnlineSoundRepository))]
+    [Singleton(typeof(OnlineGuideRepository), typeof(IOnlineGuideRepository))]
+    [Singleton(typeof(OfflineGuideRepository), typeof(IOfflineGuideRepository))]
+    [Singleton(typeof(SoundCache), typeof(ISoundCache))]
+    [Singleton(typeof(GuideCache), typeof(IGuideCache))]
+    [Singleton(typeof(SoundService), typeof(ISoundService))]
+    [Singleton(typeof(GuideService), typeof(IGuideService))]
+    [Singleton(typeof(FocusHistoryRepository), typeof(IFocusHistoryRepository))]
+    [Singleton(typeof(LocalSettings), typeof(IUserSettings))]
+    [Singleton(typeof(SoundMixService), typeof(ISoundMixService))]
+    [Singleton(typeof(Renamer), typeof(IRenamer))]
+    [Singleton(typeof(UpdateService), typeof(IUpdateService))]
+    [Singleton(typeof(ReswLocalizer), typeof(ILocalizer))]
+    [Singleton(typeof(FileWriter), typeof(IFileWriter))]
+    [Singleton(typeof(FilePicker), typeof(IFilePicker))]
+    [Singleton(typeof(FocusToastService), typeof(IFocusToastService))]
+    [Singleton(typeof(ToastService), typeof(IToastService))]
+    [Singleton(typeof(Services.Uwp.Navigator), typeof(Services.INavigator))]
+    [Singleton(typeof(CompactNavigator), typeof(ICompactNavigator))]
+    [Singleton(typeof(CloudFileWriter), typeof(ICloudFileWriter))]
+    [Singleton(typeof(PlayerTelemetryTracker))]
+    [Singleton(typeof(SoundEffectsService), typeof(ISoundEffectsService))]
+    [Singleton(typeof(PreviewService), typeof(IPreviewService))]
+    [Singleton(typeof(StoreService), typeof(IIapService))]
+    [Singleton(typeof(WindowsDownloadManager), typeof(IDownloadManager))]
+    [Singleton(typeof(ScreensaverService), typeof(IScreensaverService))]
+    [Singleton(typeof(Services.Uwp.SystemInfoProvider), typeof(Services.ISystemInfoProvider))]
+    [Singleton(typeof(AssetsReader), typeof(Tools.IAssetsReader))]
+    [Singleton(typeof(MixMediaPlayerService), typeof(IMixMediaPlayerService))]
+    [Singleton(typeof(WindowsSystemMediaControls), typeof(ISystemMediaControls))]
+    [Singleton(typeof(AudioDeviceService), typeof(IAudioDeviceService))]
+    [Singleton(typeof(WindowsMediaPlayerFactory), typeof(IMediaPlayerFactory))]
+    private static partial void ConfigureServices(IServiceCollection services);
 }


### PR DESCRIPTION
This PR switches the DI registration to CommunityToolkit.Extensions.DependencyInjection. This makes the resolution faster, trim/AOT safe, and also benefits from the new analyzers to catch some registration errors (eg. there was a duplicate one).