### PR TITLE
Updated Polish strings ;3

### DIFF
--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
@@ -783,7 +783,7 @@
         </trans-unit>
         <trans-unit id="SettingsCompactMode" translate="yes" xml:space="preserve">
           <source>Open Ambie Mini when focusing</source>
-          <target state="translated">Otwórz Ambie Mini podczas korzystania z licznika koncentracji</target>
+          <target state="translated">Otwórz Mini z licznikiem koncentracji</target>
         </trans-unit>
         <trans-unit id="DurationText" translate="yes" xml:space="preserve">
           <source>Duration</source>
@@ -975,7 +975,7 @@
         </trans-unit>
         <trans-unit id="SettingsPlayAfterFocusHeader" translate="yes" xml:space="preserve">
           <source>Continue sounds after focusing</source>
-          <target state="translated">Kontynuuj odtwarzanie dźwięków po zakończeniu sesji koncentracji</target>
+          <target state="translated">Kontynuuj odtwarzanie po sesji koncentracji</target>
         </trans-unit>
         <trans-unit id="RelaxText" translate="yes" xml:space="preserve">
           <source>Relax</source>

--- a/src/AmbientSounds.Uwp/Strings/pl-PL/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/pl-PL/Resources.resw
@@ -593,7 +593,7 @@
     <value>Darmowe w tym tygodniu!</value>
   </data>
   <data name="SettingsCompactMode" xml:space="preserve">
-    <value>Otwórz Ambie Mini podczas korzystania z licznika koncentracji</value>
+    <value>Otwórz Mini z licznikiem koncentracji</value>
   </data>
   <data name="DurationText" xml:space="preserve">
     <value>Czas trwania</value>
@@ -737,7 +737,7 @@
     <value>Dźwięki będą nadal odtwarzane po zakończeniu sesji koncentracji</value>
   </data>
   <data name="SettingsPlayAfterFocusHeader" xml:space="preserve">
-    <value>Kontynuuj odtwarzanie dźwięków po zakończeniu sesji koncentracji</value>
+    <value>Kontynuuj odtwarzanie po sesji koncentracji</value>
   </data>
   <data name="RelaxText" xml:space="preserve">
     <value>Relaksować się</value>


### PR DESCRIPTION
Made the unnecessairly (lmk if i even spelled that right) long string in the Mini view more readable in Polish:

**Before:**
![image](https://github.com/jenius-apps/ambie/assets/79228174/a5798866-ae4b-41f4-a37c-1f1549da7721)


**After:**
![image](https://github.com/jenius-apps/ambie/assets/79228174/fd9cdea2-b3d5-46c1-afc8-a00f3710b116)

changes ofc approved:
![image](https://github.com/jenius-apps/ambie/assets/79228174/cb42bd01-b94b-4c02-a63a-829dc53db20f)

<sub>also tysm for a+ 🫶</sub>