### PR TITLE
Polish string fix

### DIFF
--- a/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
+++ b/src/AmbientSounds.Uwp/MultilingualResources/AmbientSounds.Uwp.pl-PL.xlf
@@ -995,7 +995,7 @@
         </trans-unit>
         <trans-unit id="SearchText" translate="yes" xml:space="preserve">
           <source>Search</source>
-          <target state="translated">Szukać</target>
+          <target state="translated">Szukaj</target>
         </trans-unit>
         <trans-unit id="QuickResumeTitle" translate="yes" xml:space="preserve">
           <source>Quick Resume</source>

--- a/src/AmbientSounds.Uwp/Strings/pl-PL/Resources.resw
+++ b/src/AmbientSounds.Uwp/Strings/pl-PL/Resources.resw
@@ -752,7 +752,7 @@
     <value>Oops! Nie mogliśmy znaleźć tego dźwięku. Zobaczymy, czy uda nam się go dodać w przyszłości</value>
   </data>
   <data name="SearchText" xml:space="preserve">
-    <value>Szukać</value>
+    <value>Szukaj</value>
   </data>
   <data name="QuickResumeTitle" xml:space="preserve">
     <value>Szybkie wznawianie</value>


### PR DESCRIPTION
TLDR: Szukać/To search -> Szukaj/Search

This is/was a grammar error often made by automatic translators since they don't have the translation's context.
Also I gave up on that AutoPlay PR because resolving Git conflicts is not for the weak.
